### PR TITLE
Fix for parent_option overwrites

### DIFF
--- a/app/models/dropdown_option.rb
+++ b/app/models/dropdown_option.rb
@@ -1,4 +1,4 @@
 class DropdownOption < ApplicationRecord
-  has_one :question, as: :parent_option
+  has_one :child_question, class_name: 'Question', as: :parent_option
   belongs_to :question
 end


### PR DESCRIPTION
After a lot of scouring through ActiveRecord source and trying to understand why this was happening, it turned out to be a really simple fix -- changing the `has_one` identifier and explicitly specifying the class.

Resolves #52.