### PR TITLE
Seed for portfolios, buildings, building types, categories, users, and questions

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,5 @@
 class Question < ApplicationRecord
-  enum question_type: [ :dropdown, :free, :range ]
+  enum question_type: [ :free, :dropdown, :range ]
   enum status: [ :draft, :published ]
 
   belongs_to :building_type

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20171015204818) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010181113) do
+ActiveRecord::Schema.define(version: 20171012070834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,9 @@ ActiveRecord::Schema.define(version: 20171010181113) do
     t.bigint "question_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "building_operator_id"
     t.index ["building_id"], name: "index_answers_on_building_id"
+    t.index ["building_operator_id"], name: "index_answers_on_building_operator_id"
     t.index ["question_id"], name: "index_answers_on_question_id"
   end
 
@@ -156,6 +158,7 @@ ActiveRecord::Schema.define(version: 20171010181113) do
     t.index ["reset_password_token"], name: "index_rmi_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "answers", "building_operators"
   add_foreign_key "answers", "buildings"
   add_foreign_key "answers", "questions"
   add_foreign_key "buildings", "portfolios"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -117,8 +117,6 @@ def generate_question(question, building_type, parent_option=nil)
     q.save!
   end
 
-  print("creating\n", q_text, " ", parent_option, " ", q.parent_option_id, "\n--------------\n")
-
   if q_type.equal? :free
     return
   end
@@ -146,11 +144,25 @@ def generate_question(question, building_type, parent_option=nil)
   end
 end
 
-large_cube_retail_questions.each { |q| generate_question(q, large_cube_retail) }
-rockclimbing_eggyolk_inc_questions.each { |q| generate_question(q, rockclimbing_eggyolk_inc) }
+large_cube_retail_questions.each_with_index do |q, i|
+  print("\rCreating #{large_cube_retail.name}"\
+  " Question #{i + 1}/#{large_cube_retail_questions.length}...")
+  generate_question(q, large_cube_retail)
+end
+
+print("\n")
+
+rockclimbing_eggyolk_inc_questions.each_with_index do |q, i|
+  print("\rCreating #{rockclimbing_eggyolk_inc.name}"\
+  " Question #{i + 1}/#{rockclimbing_eggyolk_inc_questions.length}...")
+  generate_question(q, rockclimbing_eggyolk_inc)
+end
+
+print("\n")
 
 # RMI Users
 people = [
+['Test', 'RMI', 'rmi@test.com', '18005558888', 'password'],
 ['Eleanore', 'Donnelly', 'raleigh.hammes@berkeley.edu', '16877036527', '^Vbf=Dtst('],
 ['Orland', 'Johns', 'laurence.spence@berkeley.edu', '18451135957', '}jylKd71Z4n-^Gh'],
 ['Miss', 'Winifred', 'qvolkman@berkeley.edu', '11706668976', '`j)L]$_~A];Qk'],
@@ -167,6 +179,7 @@ people = [
 ['Dr.', 'Adrain', 'uhoppe@berkeley.edu', '111846821714', 'IOAI*=5SXw0Y'],
 ['Jarret', 'Schuppe', 'smarquardt@berkeley.edu', '13683518803', 'ExZB1/N6_#-D7yK('],
 ['Melba', 'Moen', 'goyette.dedric@berkeley.edu', '18889991010', 'j!b]J_p8,OHHm'],
+['Test', 'Asset Manager', 'ass@test.com', '18005558888', 'password'],
 ['Elisha', 'Kunde', 'cristobal74@berkeley.edu', '15808548569', 'AM+%fU*Z@jo~hMk'],
 ['Leslie', 'Rowe', 'rhane@berkeley.edu', '18889991010', ']4tModt6hcU?'],
 ['Karson', 'Cronin', 'chester25@berkeley.edu', '18889991010', 'S5&mk]cglC|`S('],
@@ -183,6 +196,7 @@ people = [
 ['Mr.', 'Terrill', 'conor.predovic@berkeley.edu', '17357877308', 'dj}wdd:(m5pt;pRR'],
 ['Albin', 'Franecki', 'gusikowski.camr@berkeley.edu', '18889991010', 'r/{#7U]=_fxb^*g'],
 ['Prof.', 'Shayne', 'derick.wilderma@berkeley.edu', '14497740519', 'gySl11O@wDxr'],
+['Test', 'Building Operator', 'op@test.com', '18005558888', 'password'],
 ['Eleazar', 'Paucek', 'judy.howell@berkeley.edu', '14294080787', 'XY6P.@(9SNAs'],
 ['Madilyn', 'Schoen', 'delta.smith@berkeley.edu', '18889991010', '!dgz,^n$=MS|HFw8JP'],
 ['Dr.', 'Woodrow', 'bogan.gisselle@berkeley.edu', '18889991010', '_AlwAS)Y4t;nU7Ue'],
@@ -213,17 +227,24 @@ def person(p)
   }
 end
 
-rmi_users = people[0..1 * users_per_type].map do |p|
+rmi_users = people[0..1 * users_per_type].each_with_index.map do |p, i|
+  print("\rCreating RMI User #{i}/#{users_per_type}...")
   RmiUser.create(person(p))
 end
 
+print("\n")
+
 # Asset Manager Users
-asset_managers = people[1 * users_per_type..2 * users_per_type].map do |p|
+asset_managers = people[1 * users_per_type..2 * users_per_type].each_with_index.map do |p, i|
+  print("\rCreating Asset Manager #{i}/#{users_per_type}...")
   AssetManager.create(person(p))
 end
 
+print("\n")
+
 # Building Operator Users
-building_operators = people[2 * users_per_type..3 * users_per_type].map do |p|
+building_operators = people[2 * users_per_type..3 * users_per_type].each_with_index.map do |p, i|
+  print("\rCreating Building Operator #{i}/#{users_per_type}...")
   BuildingOperator.create(person(p))
 end
 
@@ -265,11 +286,15 @@ portfolios = asset_managers.map do |a|
 end
 
 # Buildings
-Array(0...portfolios.length).each do |i|
+print("\n")
+Array(0...portfolios.length).each_with_index do |i, portfolio_index|
+  print("Creating Portfolio #{portfolio_index}/#{portfolios.length - 1}")
   portfolio = portfolios[i]
   asset_manager = portfolio.asset_manager
 
-  Array(0...addresses.length).each do |j|
+  print("\n")
+  Array(0...addresses.length).each_with_index do |j, building_index|
+    print("\r- Creating Building #{building_index}/#{addresses.length - 1}")
     location = generate_location(addresses[j])
     building = Building.new({
       portfolio: portfolio,
@@ -288,4 +313,5 @@ Array(0...portfolios.length).each do |i|
 
     building.save!
   end
+  print("\n")
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,46 +1,145 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
+## BuildingTypes
 
 large_cube_retail = BuildingType.create({ name: 'Large Cube Retail' })
 rockclimbing_eggyolk_inc = BuildingType.create({ name: 'REI' })
 
-free_questions: [
-  'Describe the kind of cubes you enjoy most.',
-  'How many cubes do you currently have in your building?',
-  'Please provide your three desired cube colors.'
+# Questions
+# -----
+# FORMAT
+# [<text>, <type>, <array of options>, <array of dependents (or nils)>]
+
+no_dependents = Array.new(3, nil);
+safe_maximum = 2 ** 53 - 1
+
+large_cube_retail_questions = [
+  ['Describe the kind of cubes you enjoy most.', :free]
+  ['How many cubes do you currently have in your building?', :free]
+  ['Please provide your three desired cube colors.', :free],
+  ['Who manufactures your cubes?', :dropdown, 
+    ['Apple', 'Google', 'Samsung'], no_dependents],
+  ['During which time slot are you available for a cube inspection?', :dropdown,
+    ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents],
+  ['What model are your cubes?', :dropdown,
+    ['Model T', 'Corolla', 'Leaf'], no_dependents],
+  ['Please specify the amount of faces your cube has.', :range,
+    [[0, 6]], no_dependents],
+  ['How many corners does your cube have?', :range,
+    [[0, 8]], no_dependents],
+  ['Please evaluate your cube on a scale of 1-10: 1 = Strongly Disagree, 10 = Strongly Agree', :range,
+    [[0, 10]], no_dependents],
+  [
+    'Do you love your cube?', :dropdown,
+    ['Yes.', 'Not really'],
+    [[
+      'How many times a day do you tell your cube that you love it?', :range,
+      [[0, 3], [4, 7], [8, 10]],
+      [
+        [ 'List some ways you can spend more time with your cube.', :free ],
+        [ 'What has been your favorite reaction to affection shown towards your cube?', :free ],
+        [ 'Does your cube enjoy the attention?', :dropdown, ['Yes', 'No'], [nil, nil] ]
+      ]
+    ], nil]
+  ]
 ]
 
-dropdown_questions: [
-  ['Who manufactures your cubes?', 'Apple', 'Google', 'Samsung'],
-  ['During which time slot are you available for a cube inspection?', '12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM']
-  ['What model are your cubes?', 'Model T', ''
+rockclimbing_eggyolk_inc_questions = [
+  ['Please provide the name of the rockclimbing gym of your eggyolk\'s choice.', :free],
+  [
+    'How many years has your eggyolk been rockclimbing?', :range,
+    [[0, 2], [3, 5], [6, safe_maximum]],
+    [
+      ['Has your eggyolk taken lessons?', :free],
+      [
+        'How does your egg prepare for rockclimbing?', :dropdown,
+        ['Hardboiled', 'Scrambled', 'Overeasy'], no_dependents
+      ],
+      [
+        'How many hours a day does your eggyolk spend rockclimbing?', :range,
+        [[0, 4], [5, 8], [0, 24]],
+        [
+          ['Describe your eggyolk\'s work-life balance.', :free],
+          ['Is your eggyolk often exhausted?', :dropdown, ['Yes', 'No'], no_dependents],
+          nil
+        ]
+      ]
+    ]
+  ],
+  [
+    'Does your eggyolk have any allergies?', :dropdown,
+    ['Yes', 'No'],
+    [['List any foods your eggyolk may be allergic to.', :free], nil] 
+  ],
+  ['What is your eggyolk\'s budget on rockclimbing?', :range,
+    [[0, 100], [101, 500], [501, safe_maximum]],
+    [nil, nil, ['Is your eggyolk employed?', :dropdown, ['Yes', 'No'], no_dependents]]
+  ],
+  ['Briefly describe how your eggyolk discovered rockclimbing.', :free],
+  ['Explain why your eggyolk enjoys rockclimbing, if applicable.', :free],
+  ['What kind of shoes does your eggyolk use when rockclimbing?', :dropdown,
+    ['Laces', 'Velcro', 'Slipper'], no_dependents
+  ]
+  ['Which kind of rockclimbing does your eggyolk engage in?', :dropdown,
+    ['Bouldering', 'Top Rope Climbing', 'Mountaineering'], no_dependents
+  ],
+  ['How many shoes does your eggyolk own?', :range, [[0, 10]], no_dependents],
+  ['What size shoe is your eggyolk?', :range, [[0, 20]], no_dependents]
 ]
 
+def generate_question(question, building_type, parent_option=nil)
+  if question.nil?
+    return
+  end
+  q_text = question[0]
+  q_type = question[1]
 
-questions = Question.create([{
-  question_type: :free,
-  status: :published,
-  text: ,
-  building_type: large_cube_retail
-}, {
-  question_type: :free,
-  status: :published,
-  text: ,
-  building_type: large_cube_retail
-}, {
-  question_type: :free,
-  status: :published,
-  text: 
-  building_type: large_cube_retail
-}, {
-  question_type: :dropdown,
-  status: :published,
-  text: 
-}]
+  if q_type.equal? :free
+    Question.create({
+      question_type: :free,
+      status: :published,
+      text: q_text,
+      building_type: building_type,
+      parent_option: parent_option
+      })
+    return
+  end
+
+  q_options = question[2]
+  q_dependents = question[3]
+  if q_type.equal? :dropdown
+    q = Question.create({
+      question_type: :dropdown,
+      status: :published,
+      text: q_text,
+      building_type: building_type,
+      parent_option: parent_option
+      })
+    q_options.map do |option|
+      DropdownOption.create({
+        text: option,
+        question: q
+        })
+    end
+  end
+  if q_type.equal? :range
+    q = Question.create({
+      question_type: :range,
+      status: :published,
+      text: q_text,
+      building_type: building_type,
+      parent_option: parent_option
+      })
+    q_options.map do |option|
+      RangeOption.create({
+        min: option[0],
+        max: option[1],
+        question: q
+        })
+    end
+  end
+
+  Array(0...q_options.length).each do |i|
+    generate_question(q_dependents[i], building_type, q_options[i])
+  end
+end
+
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -123,7 +123,7 @@ def generate_question(question, building_type, parent_option=nil)
   if q_type.equal? :range
     q = Question.create({
       question_type: :range,
-      status: :published,
+      status: :published, 
       text: q_text,
       building_type: building_type,
       parent_option: parent_option
@@ -142,4 +142,30 @@ def generate_question(question, building_type, parent_option=nil)
   end
 end
 
+large_cube_retail_questions.each { |q| generate_question(q, large_cube_retail) }
+rockclimbing_eggyolk_inc_questions.each { |q| generate_question(q, rockclimbing_eggyolk_inc) }
+
+# Locations
+# -----
+# FORMAT
+# [<name>, <address>, <city>, <state>, <zip>]
+addresses = [
+  ['Unit 1', '2650 Durant Ave', 'Berkeley', :California, 94704],
+  ['Northside Cafe', '1878 Euclid Ave', 'Berkeley', :California, 94709],
+  ['MLK Student Union', '2560 Bancroft Way', 'Berkeley', :California, 94704],
+  ['SMCHS', '22062 Antonio Pkwy', 'Rancho Santa Margarita', :California, 92688],
+  ['Monta Vista HS', '21840 McClellan Rd', 'Cupertino', :California, 95014],
+  ['Archbishop Mitty', '5000 Mitty Way', 'San Jose', :California, 95129],
+  ['The House', '2495 Bancroft Way', 'Berkeley', :California, 94720],
+  ['Googleplex', '1600 Amphitheatre Pkwy', 'Mountain View', :California, 94043],
+  ['Apple Park', '1 Apple Park Way', 'Cupertino', :California, 95014],
+  ['Facebook HQ', '1 Hacker Way', 'Menlo Park', :California, 94025],
+  ['Mozilla HQ', '2 Harrison St', 'San Francisco', :California, 94105],
+  ['Horizons HQ', '450 9th St', 'San Francisco', :California, 94103],
+  ['Little Gem Belgian Waffles', '2468 Telegraph Ave A', 'Berkeley', :California, 94704],
+  ['Gypsy\'s Trattoria Italiana', '2519 Durant Ave', 'Berkeley', :California, 94704],
+]
+
+
+# Buildings
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,14 +1,14 @@
 ## BuildingTypes
 
-large_cube_retail = BuildingType.create!({ name: 'Large Cube Retail' })
-rockclimbing_eggyolk_inc = BuildingType.create!({ name: 'REI' })
+large_cube_retail = BuildingType.create!(name: 'Large Cube Retail')
+rockclimbing_eggyolk_inc = BuildingType.create!(name: 'REI')
 
 # Categories
-other = Category.create!({ name: 'Miscellaneous' })
-cube_facts = Category.create!({ name: 'Basic Information' })
-cube_care = Category.create!({ name: 'Caring for Your Cube' })
-rockclimbing_skill = Category.create!({ name: 'Skill Evaluation' })
-eggyolk_information = Category.create!({ name: 'Personal Information' })
+other = Category.create!(name: 'Miscellaneous')
+cube_facts = Category.create!(name: 'Basic Information')
+cube_care = Category.create!(name: 'Caring for Your Cube')
+rockclimbing_skill = Category.create!(name: 'Skill Evaluation')
+eggyolk_information = Category.create!(name: 'Personal Information')
 
 
 # Questions
@@ -17,14 +17,14 @@ eggyolk_information = Category.create!({ name: 'Personal Information' })
 # [<text>, <category>, <type>, <array of options>, <array of dependents (or nils)>]
 
 no_dependents = Array.new(3, nil);
-safe_maximum = 2 ** 31 - 1
+safe_maximum = 2**31 - 1
 
 large_cube_retail_questions = [
   ['Describe the kind of cubes you enjoy most.', cube_facts, :free],
   ['How many cubes do you currently have in your building?', cube_facts, :free],
   ['Please provide your three desired cube colors.', cube_facts, :free],
   ['Who manufactures your cubes?', cube_facts, :dropdown, 
-    ['Apple', 'Google', 'Samsung'], no_dependents],
+    %w(Apple Google Samsung), no_dependents],
   ['During which time slot are you available for a cube inspection?', cube_facts, :dropdown,
     ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents],
   ['What model are your cubes?', cube_facts, :dropdown,
@@ -110,7 +110,7 @@ def generate_question(question, building_type, parent_option=nil)
     text: q_text,
     building_type: building_type,
     category: q_category
-    })
+  })
 
   unless parent_option.nil?
     q.parent_option = parent_option
@@ -128,7 +128,7 @@ def generate_question(question, building_type, parent_option=nil)
       DropdownOption.create!({
         text: option,
         question: q
-        })
+      })
     end
   end
   if q_type.equal? :range
@@ -137,7 +137,7 @@ def generate_question(question, building_type, parent_option=nil)
         min: option[0],
         max: option[1],
         question: q
-        })
+      })
     end
   end
 
@@ -151,54 +151,54 @@ rockclimbing_eggyolk_inc_questions.each { |q| generate_question(q, rockclimbing_
 
 # RMI Users
 people = [
-["Eleanore", "Donnelly", "raleigh.hammes@berkeley.edu", "16877036527", "^Vbf=Dt'st("],
-["Orland", "Johns", "laurence.spence@berkeley.edu", "18451135957", "}jylKd71Z4n-^Gh"],
-["Miss", "Winifred", "qvolkman@berkeley.edu", "11706668976", "`j)L]$_~A];Qk"],
-["Jermey", "Klocko", "christiansen.vi@berkeley.edu", "18889991010", "ARpil]n|s%#2Kxs*r"],
-["Garrick", "Armstrong", "nat99@berkeley.edu", "18889991010", "Y.;1#f-UilR:D/"],
-["Prof.", "Golden", "schiller.vivien@berkeley.edu", "18889991010", "QZ`_42v#J;R91)s_x"],
-["Mr.", "Henri", "quinten59@berkeley.edu", "14328287160", ":BJ{KqA8$lNmMR[*/"],
-["Joanny", "Hansen", "barrows.erna@berkeley.edu", "18889991010", "mBqa%k6zL3+Pi+K7?"],
-["Alanis", "Rempel", "csatterfield@berkeley.edu", "18889991010", "1Bq]7nNk)*w5"],
-["Gennaro", "Simonis", "zmitchell@berkeley.edu", "114050090458", "fLN'-X_j[n'`9LnZz"],
-["Dr.", "Donato", "cory.rempel@berkeley.edu", "18889991010", "wwhox/8|_}HN"],
-["Dr.", "Brielle", "fredrick.kuhic@berkeley.edu", "11512248619", ")&syqTeJh]E"],
-["Lexi", "Berge", "johnny33@berkeley.edu", "110895664254", "'9VHZ3+0a)S%]"],
-["Dr.", "Adrain", "uhoppe@berkeley.edu", "111846821714", "IOAI*=5SXw0Y"],
-["Jarret", "Schuppe", "smarquardt@berkeley.edu", "13683518803", "ExZB1/N6_#-D7yK("],
-["Melba", "Moen", "goyette.dedric@berkeley.edu", "18889991010", "j!b]J_p8,OHHm"],
-["Elisha", "Kunde", "cristobal74@berkeley.edu", "15808548569", "AM+%fU*Z@jo~hMk"],
-["Leslie", "Rowe", "rhane@berkeley.edu", "18889991010", "]4tModt6hcU?"],
-["Karson", "Cronin", "chester25@berkeley.edu", "18889991010", "S5&mk]cglC|`S("],
-["Jerad", "Gulgowski", "drew99@berkeley.edu", "17906026970", "OLyu|iX7{~"],
-["Consuelo", "Schaden", "linnie90@berkeley.edu", "18889991010", "@PUuq}1m{22eEni,-H%"],
-["Osborne", "Lockman", "jensen.satterfi@berkeley.edu", "14708275094", "tmd(|$Z.9g$m9"],
-["Dr.", "Gust", "kamryn92@berkeley.edu", "16093469117", "4~;X|=P27G,HN*cC"],
-["Melvin", "Denesik", "deonte.rempel@berkeley.edu", "18889991010", "vg7$}D`e;j"],
-["Aliza", "Feil", "geichmann@berkeley.edu", "17632048530", "Y#1,tF+*E!O7k"],
-["Roslyn", "Bernhard", "kertzmann.terry@berkeley.edu", "12523656313", "Zjv~GsY5tU!&"],
-["Prof.", "Johnathon", "cgulgowski@berkeley.edu", "18889991010", "!7)w88p1gRmeqIci."],
-["Mrs.", "Kaya", "mariano.dickens@berkeley.edu", "18889991010", "~3ML9z7-W|k,3Eq]"],
-["Nelda", "Farrell", "emmanuelle98@berkeley.edu", "18889991010", "#+Z%15_gT?#==q@tlP@"],
-["Mr.", "Terrill", "conor.predovic@berkeley.edu", "17357877308", "dj}wdd:(m5pt;pRR"],
-["Albin", "Franecki", "gusikowski.camr@berkeley.edu", "18889991010", "r/{#7U]=_fxb^*g"],
-["Prof.", "Shayne", "derick.wilderma@berkeley.edu", "14497740519", "gySl11O@wDxr"],
-["Eleazar", "Paucek", "judy.howell@berkeley.edu", "14294080787", "XY6P.@(9SNAs"],
-["Madilyn", "Schoen", "delta.smith@berkeley.edu", "18889991010", "!dgz,^n$=MS|HFw8JP"],
-["Dr.", "Woodrow", "bogan.gisselle@berkeley.edu", "18889991010", "_AlwAS)Y4t;nU7Ue"],
-["Hortense", "Schaefer", "mayert.conor@berkeley.edu", "14848860229", "{''M,kIw)@PIoc"],
-["Larissa", "Thiel", "kristofer.carte@berkeley.edu", "17517074903", "gctu`b*Dt"],
-["Tierra", "Ziemann", "rodolfo.cruicks@berkeley.edu", "18889991010", "~d?EklM?:r;lHbhN"],
-["Nicole", "Fritsch", "annamarie58@berkeley.edu", "17921564776", "BZPTh'c0f$RA"],
-["Dexter", "Koelpin", "ycummerata@berkeley.edu", "15422438089", "*7[8}T&EZ{^|"],
-["Kara", "Johns", "nathaniel.sauer@berkeley.edu", "15875642877", "!O|t;@+b&gCh4O_O"],
-["Buck", "Boehm", "spinka.craig@berkeley.edu", "16883921783", "IhEgW$5*:kxMF$-3n#L0"],
-["Dr.", "Javonte", "xhane@berkeley.edu", "18889991010", "#m|x/;&XU"],
-["Kenyatta", "Lockman", "cklein@berkeley.edu", "18889991010", "KdZf^ibKX7[.WKm2tb5"],
-["Lewis", "Gutmann", "jerald31@berkeley.edu", "18889991010", "0g@]t$JMJ6Dvb&SR"],
-["August", "Trantow", "johnnie62@berkeley.edu", "18889991010", "3a)1E/%!Ov"],
-["Triston", "Rohan", "oconnell.jasper@berkeley.edu", "12907201773", "*wuq+3hd`eJ6I&=FwU"],
-["Merle", "Effertz", "barrows.ona@berkeley.edu", "18889991010", "CXl+`q6sEV3igp"]
+['Eleanore', 'Donnelly', 'raleigh.hammes@berkeley.edu', '16877036527', '^Vbf=Dtst('],
+['Orland', 'Johns', 'laurence.spence@berkeley.edu', '18451135957', '}jylKd71Z4n-^Gh'],
+['Miss', 'Winifred', 'qvolkman@berkeley.edu', '11706668976', '`j)L]$_~A];Qk'],
+['Jermey', 'Klocko', 'christiansen.vi@berkeley.edu', '18889991010', 'ARpil]n|s%#2Kxs*r'],
+['Garrick', 'Armstrong', 'nat99@berkeley.edu', '18889991010', 'Y.;1#f-UilR:D/'],
+['Prof.', 'Golden', 'schiller.vivien@berkeley.edu', '18889991010', 'QZ`_42v#J;R91)s_x'],
+['Mr.', 'Henri', 'quinten59@berkeley.edu', '14328287160', ':BJ{KqA8$lNmMR[*/'],
+['Joanny', 'Hansen', 'barrows.erna@berkeley.edu', '18889991010', 'mBqa%k6zL3+Pi+K7?'],
+['Alanis', 'Rempel', 'csatterfield@berkeley.edu', '18889991010', '1Bq]7nNk)*w5'],
+['Gennaro', 'Simonis', 'zmitchell@berkeley.edu', '114050090458', 'fLN-X_j[n`9LnZz'],
+['Dr.', 'Donato', 'cory.rempel@berkeley.edu', '18889991010', 'wwhox/8|_}HN'],
+['Dr.', 'Brielle', 'fredrick.kuhic@berkeley.edu', '11512248619', ')&syqTeJh]E'],
+['Lexi', 'Berge', 'johnny33@berkeley.edu', '110895664254', '9VHZ3+0a)S%]'],
+['Dr.', 'Adrain', 'uhoppe@berkeley.edu', '111846821714', 'IOAI*=5SXw0Y'],
+['Jarret', 'Schuppe', 'smarquardt@berkeley.edu', '13683518803', 'ExZB1/N6_#-D7yK('],
+['Melba', 'Moen', 'goyette.dedric@berkeley.edu', '18889991010', 'j!b]J_p8,OHHm'],
+['Elisha', 'Kunde', 'cristobal74@berkeley.edu', '15808548569', 'AM+%fU*Z@jo~hMk'],
+['Leslie', 'Rowe', 'rhane@berkeley.edu', '18889991010', ']4tModt6hcU?'],
+['Karson', 'Cronin', 'chester25@berkeley.edu', '18889991010', 'S5&mk]cglC|`S('],
+['Jerad', 'Gulgowski', 'drew99@berkeley.edu', '17906026970', 'OLyu|iX7{~'],
+['Consuelo', 'Schaden', 'linnie90@berkeley.edu', '18889991010', '@PUuq}1m{22eEni,-H%'],
+['Osborne', 'Lockman', 'jensen.satterfi@berkeley.edu', '14708275094', 'tmd(|$Z.9g$m9'],
+['Dr.', 'Gust', 'kamryn92@berkeley.edu', '16093469117', '4~;X|=P27G,HN*cC'],
+['Melvin', 'Denesik', 'deonte.rempel@berkeley.edu', '18889991010', 'vg7$}D`e;j'],
+['Aliza', 'Feil', 'geichmann@berkeley.edu', '17632048530', 'Y#1,tF+*E!O7k'],
+['Roslyn', 'Bernhard', 'kertzmann.terry@berkeley.edu', '12523656313', 'Zjv~GsY5tU!&'],
+['Prof.', 'Johnathon', 'cgulgowski@berkeley.edu', '18889991010', '!7)w88p1gRmeqIci.'],
+['Mrs.', 'Kaya', 'mariano.dickens@berkeley.edu', '18889991010', '~3ML9z7-W|k,3Eq]'],
+['Nelda', 'Farrell', 'emmanuelle98@berkeley.edu', '18889991010', '#+Z%15_gT?#==q@tlP@'],
+['Mr.', 'Terrill', 'conor.predovic@berkeley.edu', '17357877308', 'dj}wdd:(m5pt;pRR'],
+['Albin', 'Franecki', 'gusikowski.camr@berkeley.edu', '18889991010', 'r/{#7U]=_fxb^*g'],
+['Prof.', 'Shayne', 'derick.wilderma@berkeley.edu', '14497740519', 'gySl11O@wDxr'],
+['Eleazar', 'Paucek', 'judy.howell@berkeley.edu', '14294080787', 'XY6P.@(9SNAs'],
+['Madilyn', 'Schoen', 'delta.smith@berkeley.edu', '18889991010', '!dgz,^n$=MS|HFw8JP'],
+['Dr.', 'Woodrow', 'bogan.gisselle@berkeley.edu', '18889991010', '_AlwAS)Y4t;nU7Ue'],
+['Hortense', 'Schaefer', 'mayert.conor@berkeley.edu', '14848860229', '{''M,kIw)@PIoc'],
+['Larissa', 'Thiel', 'kristofer.carte@berkeley.edu', '17517074903', 'gctu`b*Dt'],
+['Tierra', 'Ziemann', 'rodolfo.cruicks@berkeley.edu', '18889991010', '~d?EklM?:r;lHbhN'],
+['Nicole', 'Fritsch', 'annamarie58@berkeley.edu', '17921564776', 'BZPThc0f$RA'],
+['Dexter', 'Koelpin', 'ycummerata@berkeley.edu', '15422438089', '*7[8}T&EZ{^|'],
+['Kara', 'Johns', 'nathaniel.sauer@berkeley.edu', '15875642877', '!O|t;@+b&gCh4O_O'],
+['Buck', 'Boehm', 'spinka.craig@berkeley.edu', '16883921783', 'IhEgW$5*:kxMF$-3n#L0'],
+['Dr.', 'Javonte', 'xhane@berkeley.edu', '18889991010', '#m|x/;&XU'],
+['Kenyatta', 'Lockman', 'cklein@berkeley.edu', '18889991010', 'KdZf^ibKX7[.WKm2tb5'],
+['Lewis', 'Gutmann', 'jerald31@berkeley.edu', '18889991010', '0g@]t$JMJ6Dvb&SR'],
+['August', 'Trantow', 'johnnie62@berkeley.edu', '18889991010', '3a)1E/%!Ov'],
+['Triston', 'Rohan', 'oconnell.jasper@berkeley.edu', '12907201773', '*wuq+3hd`eJ6I&=FwU'],
+['Merle', 'Effertz', 'barrows.ona@berkeley.edu', '18889991010', 'CXl+`q6sEV3igp']
 ]
 
 users_per_type = people.length / 3
@@ -210,7 +210,7 @@ def person(p)
     phone: p[3],
     password: p[4],
     password_confirmation: p[4]
-    }
+  }
 end
 
 rmi_users = people[0..1 * users_per_type].map do |p|
@@ -254,7 +254,7 @@ def location(l)
     address: l[1],
     state: l[3],
     zip: l[4]
-    }
+  }
 end
 
 # Portfolios
@@ -272,9 +272,9 @@ Array(0..portfolios.length).each do |i|
     building = Building.new({
       portfolio: portfolio,
       contact_email: asset_manager.email
-      })
+    })
 
-    if i % 2 == 0
+    if i.even?
       building.building_type = large_cube_retail
     else
       building.building_type = rockclimbing_eggyolk_inc

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,131 +14,126 @@ eggyolk_information = Category.create!({ name: 'Personal Information' })
 # Questions
 # -----
 # FORMAT
-# [<text>, <type>, <array of options>, <array of dependents (or nils)>]
+# [<text>, <category>, <type>, <array of options>, <array of dependents (or nils)>]
 
 no_dependents = Array.new(3, nil);
 safe_maximum = 2 ** 31 - 1
 
 large_cube_retail_questions = [
-  ['Describe the kind of cubes you enjoy most.', :free, cube_facts],
-  ['How many cubes do you currently have in your building?', :free, cube_facts],
-  ['Please provide your three desired cube colors.', :free, cube_facts],
-  ['Who manufactures your cubes?', :dropdown, 
-    ['Apple', 'Google', 'Samsung'], no_dependents, cube_facts],
-  ['During which time slot are you available for a cube inspection?', :dropdown,
-    ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents, cube_facts],
-  ['What model are your cubes?', :dropdown,
-    ['Model T', 'Corolla', 'Leaf'], no_dependents, cube_facts],
-  ['Please specify the amount of faces your cube has.', :range,
-    [[0, 6]], no_dependents, cube_facts],
-  ['How many corners does your cube have?', :range,
-    [[0, 8]], no_dependents, cube_facts],
-  ['Please evaluate your cube on a scale of 1-10: 1 = Strongly Disagree, 10 = Strongly Agree', :range,
-    [[0, 10]], no_dependents, cube_care],
+  ['Describe the kind of cubes you enjoy most.', cube_facts, :free],
+  ['How many cubes do you currently have in your building?', cube_facts, :free],
+  ['Please provide your three desired cube colors.', cube_facts, :free],
+  ['Who manufactures your cubes?', cube_facts, :dropdown, 
+    ['Apple', 'Google', 'Samsung'], no_dependents],
+  ['During which time slot are you available for a cube inspection?', cube_facts, :dropdown,
+    ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents],
+  ['What model are your cubes?', cube_facts, :dropdown,
+    ['Model T', 'Corolla', 'Leaf'], no_dependents],
+  ['Please specify the amount of faces your cube has.', cube_facts, :range,
+    [[0, 6]], no_dependents],
+  ['How many corners does your cube have?', cube_facts, :range,
+    [[0, 8]], no_dependents],
+  ['Please evaluate your cube on a scale of 1-10: 1 = Strongly Disagree, 10 = Strongly Agree', cube_care, :range,
+    [[0, 10]], no_dependents],
   [
-    'Do you love your cube?', :dropdown,
+    'Do you love your cube?', cube_care, :dropdown,
     ['Yes.', 'Not really'],
     [[
-      'How many times a day do you tell your cube that you love it?', :range,
+      'How many times a day do you tell your cube that you love it?', cube_care, :range,
       [[0, 3], [4, 7], [8, 10]],
       [
-        [ 'List some ways you can spend more time with your cube.', :free, cube_care ],
-        [ 'What has been your favorite reaction to affection shown towards your cube?', :free, cube_care ],
-        [ 'Does your cube enjoy the attention?', :dropdown, ['Yes', 'No'], [nil, nil], cube_care ]
-      ], cube_care
-    ], nil],
-    cube_care
+        [ 'List some ways you can spend more time with your cube.', cube_care, :free ],
+        [ 'What has been your favorite reaction to affection shown towards your cube?', cube_care, :free ],
+        [ 'Does your cube enjoy the attention?', cube_care, :dropdown, ['Yes', 'No'], [nil, nil] ]
+      ]
+    ], nil]
   ]
 ]
 
 rockclimbing_eggyolk_inc_questions = [
-  ['Please provide the name of the rockclimbing gym of your eggyolk\'s choice.', :free],
+  ['Please provide the name of the rockclimbing gym of your eggyolk\'s choice.', rockclimbing_skill, :free],
   [
-    'How many years has your eggyolk been rockclimbing?', :range,
+    'How many years has your eggyolk been rockclimbing?', rockclimbing_skill, :range,
     [[0, 2], [3, 5], [6, safe_maximum]],
     [
-      ['Has your eggyolk taken lessons?', :free],
+      ['Has your eggyolk taken lessons?', rockclimbing_skill, :free],
       [
-        'How does your egg prepare for rockclimbing?', :dropdown,
+        'How does your egg prepare for rockclimbing?', rockclimbing_skill, :dropdown,
         ['Hardboiled', 'Scrambled', 'Overeasy'], no_dependents
       ],
       [
-        'How many hours a day does your eggyolk spend rockclimbing?', :range,
+        'How many hours a day does your eggyolk spend rockclimbing?', rockclimbing_skill, :range,
         [[0, 4], [5, 8], [0, 24]],
         [
-          ['Describe your eggyolk\'s work-life balance.', :free],
-          ['Is your eggyolk often exhausted?', :dropdown, ['Yes', 'No'], no_dependents],
+          ['Describe your eggyolk\'s work-life balance.', rockclimbing_skill, :free],
+          ['Is your eggyolk often exhausted?', rockclimbing_skill, :dropdown, ['Yes', 'No'], no_dependents],
           nil
         ]
       ]
     ]
   ],
   [
-    'Does your eggyolk have any allergies?', :dropdown,
+    'Does your eggyolk have any allergies?', eggyolk_information, :dropdown,
     ['Yes', 'No'],
-    [['List any foods your eggyolk may be allergic to.', :free], nil] 
+    [['List any foods your eggyolk may be allergic to.', eggyolk_information, :free], nil] 
   ],
-  ['What is your eggyolk\'s budget on rockclimbing?', :range,
+  ['What is your eggyolk\'s budget on rockclimbing?', eggyolk_information, :range,
     [[0, 100], [101, 500], [501, safe_maximum]],
-    [nil, nil, ['Is your eggyolk employed?', :dropdown, ['Yes', 'No'], no_dependents]]
+    [nil, nil, ['Is your eggyolk employed?', eggyolk_information, :dropdown, ['Yes', 'No'], no_dependents]]
   ],
-  ['Briefly describe how your eggyolk discovered rockclimbing.', :free],
-  ['Explain why your eggyolk enjoys rockclimbing, if applicable.', :free],
-  ['What kind of shoes does your eggyolk use when rockclimbing?', :dropdown,
+  ['Briefly describe how your eggyolk discovered rockclimbing.', eggyolk_information, :free],
+  ['Explain why your eggyolk enjoys rockclimbing, if applicable.', eggyolk_information, :free],
+  ['What kind of shoes does your eggyolk use when rockclimbing?', eggyolk_information, :dropdown,
     ['Laces', 'Velcro', 'Slipper'], no_dependents
   ],
-  ['Which kind of rockclimbing does your eggyolk engage in?', :dropdown,
+  ['Which kind of rockclimbing does your eggyolk engage in?', eggyolk_information, :dropdown,
     ['Bouldering', 'Top Rope Climbing', 'Mountaineering'], no_dependents
   ],
-  ['How many shoes does your eggyolk own?', :range, [[0, 10]], no_dependents],
-  ['What size shoe is your eggyolk?', :range, [[0, 20]], no_dependents]
+  ['How many shoes does your eggyolk own?', eggyolk_information, :range, [[0, 10]], no_dependents],
+  ['What size shoe is your eggyolk?', eggyolk_information, :range, [[0, 20]], no_dependents]
 ]
 
 def generate_question(question, building_type, parent_option=nil)
   if question.nil?
     return
   end
+
   q_text = question[0]
-  q_type = question[1]
+  q_category = question[1]
+  q_type = question[2]
+  q_options = question[3]
+  q_dependents = question[4]
+
+  q = Question.create!({
+    question_type: q_type,
+    status: :published,
+    text: q_text,
+    building_type: building_type,
+    category: q_category
+    })
+
+  unless parent_option.nil?
+    q.parent_option = parent_option
+    q.save!
+  end
+
+  print("creating\n", q_text, " ", parent_option, " ", q.parent_option_id, "\n--------------\n")
 
   if q_type.equal? :free
-    Question.create!({
-      question_type: :free,
-      status: :published,
-      text: q_text,
-      building_type: building_type,
-      parent_option: parent_option
-      })
     return
   end
 
-  q_options = question[2]
-  q_dependents = question[3]
   if q_type.equal? :dropdown
-    q = Question.create!({
-      question_type: :dropdown,
-      status: :published,
-      text: q_text,
-      building_type: building_type,
-      parent_option: parent_option
-      })
-    q_options = q_options.map do |option|
-      DropdownOption.create({
+    q_options_saved = q_options.map do |option|
+      DropdownOption.create!({
         text: option,
         question: q
         })
     end
   end
   if q_type.equal? :range
-    q = Question.create!({
-      question_type: :range,
-      status: :published, 
-      text: q_text,
-      building_type: building_type,
-      parent_option: parent_option
-      })
-    q_options = q_options.map do |option|
-      RangeOption.create({
+    q_options_saved = q_options.map do |option|
+      RangeOption.create!({
         min: option[0],
         max: option[1],
         question: q
@@ -146,37 +141,13 @@ def generate_question(question, building_type, parent_option=nil)
     end
   end
 
-  Array(0...q_options.length).each do |i|
-    generate_question(q_dependents[i], building_type, q_options[i])
+  Array(0...q_options_saved.length).each do |i|
+    generate_question(q_dependents[i], building_type, q_options_saved[i])
   end
 end
 
 large_cube_retail_questions.each { |q| generate_question(q, large_cube_retail) }
 rockclimbing_eggyolk_inc_questions.each { |q| generate_question(q, rockclimbing_eggyolk_inc) }
-
-# Locations
-# -----
-# FORMAT
-# [<name>, <address>, <city>, <state>, <zip>]
-addresses = [
-  ['Unit 1', '2650 Durant Ave', 'Berkeley', :California, 94704],
-  ['Northside Cafe', '1878 Euclid Ave', 'Berkeley', :California, 94709],
-  ['MLK Student Union', '2560 Bancroft Way', 'Berkeley', :California, 94704],
-  ['SMCHS', '22062 Antonio Pkwy', 'Rancho Santa Margarita', :California, 92688],
-  ['Monta Vista HS', '21840 McClellan Rd', 'Cupertino', :California, 95014],
-  ['Archbishop Mitty', '5000 Mitty Way', 'San Jose', :California, 95129],
-  ['The House', '2495 Bancroft Way', 'Berkeley', :California, 94720],
-  ['Googleplex', '1600 Amphitheatre Pkwy', 'Mountain View', :California, 94043],
-  ['Apple Park', '1 Apple Park Way', 'Cupertino', :California, 95014],
-  ['Facebook HQ', '1 Hacker Way', 'Menlo Park', :California, 94025],
-  ['Mozilla HQ', '2 Harrison St', 'San Francisco', :California, 94105],
-  ['Horizons HQ', '450 9th St', 'San Francisco', :California, 94103],
-  ['Little Gem Belgian Waffles', '2468 Telegraph Ave A', 'Berkeley', :California, 94704],
-  ['Gypsy\'s Trattoria Italiana', '2519 Durant Ave', 'Berkeley', :California, 94704],
-  ['People\'s Park', '2556 Haste St', 'Berkeley', :California, 94704],
-]
-
-# Buildings
 
 # RMI Users
 people = [
@@ -231,23 +202,89 @@ people = [
 ]
 
 users_per_type = people.length / 3
-rmi_users = people[0..1 * users_per_type].map do |p|
-  RmiUser.create({
+def person(p)
+  {
     first_name: p[0],
     last_name: p[1],
     email: p[2],
     phone: p[3],
     password: p[4],
     password_confirmation: p[4]
-    })
+    }
 end
 
-# people[1 * users_per_type..2 * users_per_type].map{ |p| AssetManager.create({ first_name: }) }
-# people[2 * users_per_type..3 * users_per_type].map{ |p| }
-
+rmi_users = people[0..1 * users_per_type].map do |p|
+  RmiUser.create(person(p))
+end
 
 # Asset Manager Users
+asset_managers = people[1 * users_per_type..2 * users_per_type].map do |p|
+  AssetManager.create(person(p))
+end
 
 # Building Operator Users
+building_operators = people[2 * users_per_type..3 * users_per_type].map do |p|
+  BuildingOperator.create(person(p))
+end
 
+# Locations
+# -----
+# FORMAT
+# [<name>, <address>, <city>, <state>, <zip>]
+addresses = [
+  ['Unit 1', '2650 Durant Ave', 'Berkeley', :California, 94704],
+  ['Northside Cafe', '1878 Euclid Ave', 'Berkeley', :California, 94709],
+  ['MLK Student Union', '2560 Bancroft Way', 'Berkeley', :California, 94704],
+  ['SMCHS', '22062 Antonio Pkwy', 'Rancho Santa Margarita', :California, 92688],
+  ['Monta Vista HS', '21840 McClellan Rd', 'Cupertino', :California, 95014],
+  ['Archbishop Mitty', '5000 Mitty Way', 'San Jose', :California, 95129],
+  ['The House', '2495 Bancroft Way', 'Berkeley', :California, 94720],
+  ['Googleplex', '1600 Amphitheatre Pkwy', 'Mountain View', :California, 94043],
+  ['Apple Park', '1 Apple Park Way', 'Cupertino', :California, 95014],
+  ['Facebook HQ', '1 Hacker Way', 'Menlo Park', :California, 94025],
+  ['Mozilla HQ', '2 Harrison St', 'San Francisco', :California, 94105],
+  ['Horizons HQ', '450 9th St', 'San Francisco', :California, 94103],
+  ['Little Gem Belgian Waffles', '2468 Telegraph Ave A', 'Berkeley', :California, 94704],
+  ['Gypsy\'s Trattoria Italiana', '2519 Durant Ave', 'Berkeley', :California, 94704],
+  ['People\'s Park', '2556 Haste St', 'Berkeley', :California, 94704],
+]
 
+def location(l)
+  {
+    address: l[1],
+    state: l[3],
+    zip: l[4]
+    }
+end
+
+# Portfolios
+portfolios = asset_managers.map do |a|
+  Portfolio.create!({ name: a.first_name + "'s Portfolio", asset_manager: a })
+end
+
+# Buildings
+Array(0..portfolios.length).each do |i|
+  portfolio = portfolios[i]
+  asset_manager = portfolio.asset_manager
+
+  Array(0..addresses.length).each do |j|
+    building_location = addresses[j];
+    building = Building.new({
+      portfolio: portfolio,
+      contact_email: asset_manager.email
+      })
+
+    if i % 2 == 0
+      building.building_type = large_cube_retail
+    else
+      building.building_type = rockclimbing_eggyolk_inc
+    end
+
+    building.name = building_location[0]
+    building.save!
+
+    location = Location.new(location(building_location[j]))
+    location.building = building
+    location.save!
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,42 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+
+large_cube_retail = BuildingType.create({ name: 'Large Cube Retail' })
+rockclimbing_eggyolk_inc = BuildingType.create({ name: 'REI' })
+
+free_questions: [
+  'Describe the kind of cubes you enjoy most.',
+  'How many cubes do you currently have in your building?',
+  'Please provide your three desired cube colors.'
+]
+
+dropdown_questions: [
+  ['Who manufactures your cubes?', 'Apple', 'Google', 'Samsung'],
+  ['During which time slot are you available for a cube inspection?', '12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM']
+  ['What model are your cubes?', 'Model T', ''
+]
+
+
+questions = Question.create([{
+  question_type: :free,
+  status: :published,
+  text: ,
+  building_type: large_cube_retail
+}, {
+  question_type: :free,
+  status: :published,
+  text: ,
+  building_type: large_cube_retail
+}, {
+  question_type: :free,
+  status: :published,
+  text: 
+  building_type: large_cube_retail
+}, {
+  question_type: :dropdown,
+  status: :published,
+  text: 
+}]
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,15 @@
 ## BuildingTypes
 
-large_cube_retail = BuildingType.create({ name: 'Large Cube Retail' })
-rockclimbing_eggyolk_inc = BuildingType.create({ name: 'REI' })
+large_cube_retail = BuildingType.create!({ name: 'Large Cube Retail' })
+rockclimbing_eggyolk_inc = BuildingType.create!({ name: 'REI' })
+
+# Categories
+other = Category.create!({ name: 'Miscellaneous' })
+cube_facts = Category.create!({ name: 'Basic Information' })
+cube_care = Category.create!({ name: 'Caring for Your Cube' })
+rockclimbing_skill = Category.create!({ name: 'Skill Evaluation' })
+eggyolk_information = Category.create!({ name: 'Personal Information' })
+
 
 # Questions
 # -----
@@ -9,24 +17,24 @@ rockclimbing_eggyolk_inc = BuildingType.create({ name: 'REI' })
 # [<text>, <type>, <array of options>, <array of dependents (or nils)>]
 
 no_dependents = Array.new(3, nil);
-safe_maximum = 2 ** 53 - 1
+safe_maximum = 2 ** 31 - 1
 
 large_cube_retail_questions = [
-  ['Describe the kind of cubes you enjoy most.', :free]
-  ['How many cubes do you currently have in your building?', :free]
-  ['Please provide your three desired cube colors.', :free],
+  ['Describe the kind of cubes you enjoy most.', :free, cube_facts],
+  ['How many cubes do you currently have in your building?', :free, cube_facts],
+  ['Please provide your three desired cube colors.', :free, cube_facts],
   ['Who manufactures your cubes?', :dropdown, 
-    ['Apple', 'Google', 'Samsung'], no_dependents],
+    ['Apple', 'Google', 'Samsung'], no_dependents, cube_facts],
   ['During which time slot are you available for a cube inspection?', :dropdown,
-    ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents],
+    ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents, cube_facts],
   ['What model are your cubes?', :dropdown,
-    ['Model T', 'Corolla', 'Leaf'], no_dependents],
+    ['Model T', 'Corolla', 'Leaf'], no_dependents, cube_facts],
   ['Please specify the amount of faces your cube has.', :range,
-    [[0, 6]], no_dependents],
+    [[0, 6]], no_dependents, cube_facts],
   ['How many corners does your cube have?', :range,
-    [[0, 8]], no_dependents],
+    [[0, 8]], no_dependents, cube_facts],
   ['Please evaluate your cube on a scale of 1-10: 1 = Strongly Disagree, 10 = Strongly Agree', :range,
-    [[0, 10]], no_dependents],
+    [[0, 10]], no_dependents, cube_care],
   [
     'Do you love your cube?', :dropdown,
     ['Yes.', 'Not really'],
@@ -34,11 +42,12 @@ large_cube_retail_questions = [
       'How many times a day do you tell your cube that you love it?', :range,
       [[0, 3], [4, 7], [8, 10]],
       [
-        [ 'List some ways you can spend more time with your cube.', :free ],
-        [ 'What has been your favorite reaction to affection shown towards your cube?', :free ],
-        [ 'Does your cube enjoy the attention?', :dropdown, ['Yes', 'No'], [nil, nil] ]
-      ]
-    ], nil]
+        [ 'List some ways you can spend more time with your cube.', :free, cube_care ],
+        [ 'What has been your favorite reaction to affection shown towards your cube?', :free, cube_care ],
+        [ 'Does your cube enjoy the attention?', :dropdown, ['Yes', 'No'], [nil, nil], cube_care ]
+      ], cube_care
+    ], nil],
+    cube_care
   ]
 ]
 
@@ -77,7 +86,7 @@ rockclimbing_eggyolk_inc_questions = [
   ['Explain why your eggyolk enjoys rockclimbing, if applicable.', :free],
   ['What kind of shoes does your eggyolk use when rockclimbing?', :dropdown,
     ['Laces', 'Velcro', 'Slipper'], no_dependents
-  ]
+  ],
   ['Which kind of rockclimbing does your eggyolk engage in?', :dropdown,
     ['Bouldering', 'Top Rope Climbing', 'Mountaineering'], no_dependents
   ],
@@ -93,7 +102,7 @@ def generate_question(question, building_type, parent_option=nil)
   q_type = question[1]
 
   if q_type.equal? :free
-    Question.create({
+    Question.create!({
       question_type: :free,
       status: :published,
       text: q_text,
@@ -106,14 +115,14 @@ def generate_question(question, building_type, parent_option=nil)
   q_options = question[2]
   q_dependents = question[3]
   if q_type.equal? :dropdown
-    q = Question.create({
+    q = Question.create!({
       question_type: :dropdown,
       status: :published,
       text: q_text,
       building_type: building_type,
       parent_option: parent_option
       })
-    q_options.map do |option|
+    q_options = q_options.map do |option|
       DropdownOption.create({
         text: option,
         question: q
@@ -121,14 +130,14 @@ def generate_question(question, building_type, parent_option=nil)
     end
   end
   if q_type.equal? :range
-    q = Question.create({
+    q = Question.create!({
       question_type: :range,
       status: :published, 
       text: q_text,
       building_type: building_type,
       parent_option: parent_option
       })
-    q_options.map do |option|
+    q_options = q_options.map do |option|
       RangeOption.create({
         min: option[0],
         max: option[1],
@@ -164,8 +173,81 @@ addresses = [
   ['Horizons HQ', '450 9th St', 'San Francisco', :California, 94103],
   ['Little Gem Belgian Waffles', '2468 Telegraph Ave A', 'Berkeley', :California, 94704],
   ['Gypsy\'s Trattoria Italiana', '2519 Durant Ave', 'Berkeley', :California, 94704],
+  ['People\'s Park', '2556 Haste St', 'Berkeley', :California, 94704],
 ]
 
-
 # Buildings
+
+# RMI Users
+people = [
+["Eleanore", "Donnelly", "raleigh.hammes@berkeley.edu", "16877036527", "^Vbf=Dt'st("],
+["Orland", "Johns", "laurence.spence@berkeley.edu", "18451135957", "}jylKd71Z4n-^Gh"],
+["Miss", "Winifred", "qvolkman@berkeley.edu", "11706668976", "`j)L]$_~A];Qk"],
+["Jermey", "Klocko", "christiansen.vi@berkeley.edu", "18889991010", "ARpil]n|s%#2Kxs*r"],
+["Garrick", "Armstrong", "nat99@berkeley.edu", "18889991010", "Y.;1#f-UilR:D/"],
+["Prof.", "Golden", "schiller.vivien@berkeley.edu", "18889991010", "QZ`_42v#J;R91)s_x"],
+["Mr.", "Henri", "quinten59@berkeley.edu", "14328287160", ":BJ{KqA8$lNmMR[*/"],
+["Joanny", "Hansen", "barrows.erna@berkeley.edu", "18889991010", "mBqa%k6zL3+Pi+K7?"],
+["Alanis", "Rempel", "csatterfield@berkeley.edu", "18889991010", "1Bq]7nNk)*w5"],
+["Gennaro", "Simonis", "zmitchell@berkeley.edu", "114050090458", "fLN'-X_j[n'`9LnZz"],
+["Dr.", "Donato", "cory.rempel@berkeley.edu", "18889991010", "wwhox/8|_}HN"],
+["Dr.", "Brielle", "fredrick.kuhic@berkeley.edu", "11512248619", ")&syqTeJh]E"],
+["Lexi", "Berge", "johnny33@berkeley.edu", "110895664254", "'9VHZ3+0a)S%]"],
+["Dr.", "Adrain", "uhoppe@berkeley.edu", "111846821714", "IOAI*=5SXw0Y"],
+["Jarret", "Schuppe", "smarquardt@berkeley.edu", "13683518803", "ExZB1/N6_#-D7yK("],
+["Melba", "Moen", "goyette.dedric@berkeley.edu", "18889991010", "j!b]J_p8,OHHm"],
+["Elisha", "Kunde", "cristobal74@berkeley.edu", "15808548569", "AM+%fU*Z@jo~hMk"],
+["Leslie", "Rowe", "rhane@berkeley.edu", "18889991010", "]4tModt6hcU?"],
+["Karson", "Cronin", "chester25@berkeley.edu", "18889991010", "S5&mk]cglC|`S("],
+["Jerad", "Gulgowski", "drew99@berkeley.edu", "17906026970", "OLyu|iX7{~"],
+["Consuelo", "Schaden", "linnie90@berkeley.edu", "18889991010", "@PUuq}1m{22eEni,-H%"],
+["Osborne", "Lockman", "jensen.satterfi@berkeley.edu", "14708275094", "tmd(|$Z.9g$m9"],
+["Dr.", "Gust", "kamryn92@berkeley.edu", "16093469117", "4~;X|=P27G,HN*cC"],
+["Melvin", "Denesik", "deonte.rempel@berkeley.edu", "18889991010", "vg7$}D`e;j"],
+["Aliza", "Feil", "geichmann@berkeley.edu", "17632048530", "Y#1,tF+*E!O7k"],
+["Roslyn", "Bernhard", "kertzmann.terry@berkeley.edu", "12523656313", "Zjv~GsY5tU!&"],
+["Prof.", "Johnathon", "cgulgowski@berkeley.edu", "18889991010", "!7)w88p1gRmeqIci."],
+["Mrs.", "Kaya", "mariano.dickens@berkeley.edu", "18889991010", "~3ML9z7-W|k,3Eq]"],
+["Nelda", "Farrell", "emmanuelle98@berkeley.edu", "18889991010", "#+Z%15_gT?#==q@tlP@"],
+["Mr.", "Terrill", "conor.predovic@berkeley.edu", "17357877308", "dj}wdd:(m5pt;pRR"],
+["Albin", "Franecki", "gusikowski.camr@berkeley.edu", "18889991010", "r/{#7U]=_fxb^*g"],
+["Prof.", "Shayne", "derick.wilderma@berkeley.edu", "14497740519", "gySl11O@wDxr"],
+["Eleazar", "Paucek", "judy.howell@berkeley.edu", "14294080787", "XY6P.@(9SNAs"],
+["Madilyn", "Schoen", "delta.smith@berkeley.edu", "18889991010", "!dgz,^n$=MS|HFw8JP"],
+["Dr.", "Woodrow", "bogan.gisselle@berkeley.edu", "18889991010", "_AlwAS)Y4t;nU7Ue"],
+["Hortense", "Schaefer", "mayert.conor@berkeley.edu", "14848860229", "{''M,kIw)@PIoc"],
+["Larissa", "Thiel", "kristofer.carte@berkeley.edu", "17517074903", "gctu`b*Dt"],
+["Tierra", "Ziemann", "rodolfo.cruicks@berkeley.edu", "18889991010", "~d?EklM?:r;lHbhN"],
+["Nicole", "Fritsch", "annamarie58@berkeley.edu", "17921564776", "BZPTh'c0f$RA"],
+["Dexter", "Koelpin", "ycummerata@berkeley.edu", "15422438089", "*7[8}T&EZ{^|"],
+["Kara", "Johns", "nathaniel.sauer@berkeley.edu", "15875642877", "!O|t;@+b&gCh4O_O"],
+["Buck", "Boehm", "spinka.craig@berkeley.edu", "16883921783", "IhEgW$5*:kxMF$-3n#L0"],
+["Dr.", "Javonte", "xhane@berkeley.edu", "18889991010", "#m|x/;&XU"],
+["Kenyatta", "Lockman", "cklein@berkeley.edu", "18889991010", "KdZf^ibKX7[.WKm2tb5"],
+["Lewis", "Gutmann", "jerald31@berkeley.edu", "18889991010", "0g@]t$JMJ6Dvb&SR"],
+["August", "Trantow", "johnnie62@berkeley.edu", "18889991010", "3a)1E/%!Ov"],
+["Triston", "Rohan", "oconnell.jasper@berkeley.edu", "12907201773", "*wuq+3hd`eJ6I&=FwU"],
+["Merle", "Effertz", "barrows.ona@berkeley.edu", "18889991010", "CXl+`q6sEV3igp"]
+]
+
+users_per_type = people.length / 3
+rmi_users = people[0..1 * users_per_type].map do |p|
+  RmiUser.create({
+    first_name: p[0],
+    last_name: p[1],
+    email: p[2],
+    phone: p[3],
+    password: p[4],
+    password_confirmation: p[4]
+    })
+end
+
+# people[1 * users_per_type..2 * users_per_type].map{ |p| AssetManager.create({ first_name: }) }
+# people[2 * users_per_type..3 * users_per_type].map{ |p| }
+
+
+# Asset Manager Users
+
+# Building Operator Users
+
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -249,7 +249,7 @@ addresses = [
   ['People\'s Park', '2556 Haste St', 'Berkeley', :California, 94704],
 ]
 
-def location(l)
+def generate_location(l)
   {
     name: l[0],
     address: l[1],
@@ -265,19 +265,19 @@ portfolios = asset_managers.map do |a|
 end
 
 # Buildings
-Array(0..portfolios.length).each do |i|
+Array(0...portfolios.length).each do |i|
   portfolio = portfolios[i]
   asset_manager = portfolio.asset_manager
 
-  Array(0..addresses.length).each do |j|
-    location = location(addresses[j]);
+  Array(0...addresses.length).each do |j|
+    location = generate_location(addresses[j])
     building = Building.new({
       portfolio: portfolio,
-      contact_email: asset_manager.email,
-      name: location.name,
-      address: location.city,
-      state: location.state,
-      zip: location.zip
+      name: location[:name],
+      address: location[:address],
+      city: location[:city],
+      state: location[:state],
+      zip: location[:zip]
     })
 
     if i.even?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -251,7 +251,9 @@ addresses = [
 
 def location(l)
   {
+    name: l[0],
     address: l[1],
+    city: l[2],
     state: l[3],
     zip: l[4]
   }
@@ -268,10 +270,14 @@ Array(0..portfolios.length).each do |i|
   asset_manager = portfolio.asset_manager
 
   Array(0..addresses.length).each do |j|
-    building_location = addresses[j];
+    location = location(addresses[j]);
     building = Building.new({
       portfolio: portfolio,
-      contact_email: asset_manager.email
+      contact_email: asset_manager.email,
+      name: location.name,
+      address: location.city,
+      state: location.state,
+      zip: location.zip
     })
 
     if i.even?
@@ -280,11 +286,6 @@ Array(0..portfolios.length).each do |i|
       building.building_type = rockclimbing_eggyolk_inc
     end
 
-    building.name = building_location[0]
     building.save!
-
-    location = Location.new(location(building_location[j]))
-    location.building = building
-    location.save!
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,97 +1,99 @@
 ## BuildingTypes
-
-large_cube_retail = BuildingType.create!(name: 'Large Cube Retail')
-rockclimbing_eggyolk_inc = BuildingType.create!(name: 'REI')
+def create_building_types
+  $large_cube_retail = BuildingType.create!(name: 'Large Cube Retail')
+  $rockclimbing_eggyolk_inc = BuildingType.create!(name: 'REI')
+end
 
 # Categories
-other = Category.create!(name: 'Miscellaneous')
-cube_facts = Category.create!(name: 'Basic Information')
-cube_care = Category.create!(name: 'Caring for Your Cube')
-rockclimbing_skill = Category.create!(name: 'Skill Evaluation')
-eggyolk_information = Category.create!(name: 'Personal Information')
+def create_categories
+  other = Category.create!(name: 'Miscellaneous')
+  cube_facts = Category.create!(name: 'Basic Information')
+  cube_care = Category.create!(name: 'Caring for Your Cube')
+  rockclimbing_skill = Category.create!(name: 'Skill Evaluation')
+  eggyolk_information = Category.create!(name: 'Personal Information')
 
+  no_dependents = Array.new(3, nil);
+  safe_maximum = 2**31 - 1
+
+  $large_cube_retail_questions = [
+    ['Describe the kind of cubes you enjoy most.', cube_facts, :free],
+    ['How many cubes do you currently have in your building?', cube_facts, :free],
+    ['Please provide your three desired cube colors.', cube_facts, :free],
+    ['Who manufactures your cubes?', cube_facts, :dropdown, 
+      %w(Apple Google Samsung), no_dependents],
+    ['During which time slot are you available for a cube inspection?', cube_facts, :dropdown,
+      ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents],
+    ['What model are your cubes?', cube_facts, :dropdown,
+      ['Model T', 'Corolla', 'Leaf'], no_dependents],
+    ['Please specify the amount of faces your cube has.', cube_facts, :range,
+      [[0, 6]], no_dependents],
+    ['How many corners does your cube have?', cube_facts, :range,
+      [[0, 8]], no_dependents],
+    ['Please evaluate your cube on a scale of 1-10: 1 = Strongly Disagree, 10 = Strongly Agree', cube_care, :range,
+      [[0, 10]], no_dependents],
+    [
+      'Do you love your cube?', cube_care, :dropdown,
+      ['Yes.', 'Not really'],
+      [[
+        'How many times a day do you tell your cube that you love it?', cube_care, :range,
+        [[0, 3], [4, 7], [8, 10]],
+        [
+          [ 'List some ways you can spend more time with your cube.', cube_care, :free ],
+          [ 'What has been your favorite reaction to affection shown towards your cube?', cube_care, :free ],
+          [ 'Does your cube enjoy the attention?', cube_care, :dropdown, ['Yes', 'No'], [nil, nil] ]
+        ]
+      ], nil]
+    ]
+  ]
+
+  $rockclimbing_eggyolk_inc_questions = [
+    ['Please provide the name of the rockclimbing gym of your eggyolk\'s choice.', rockclimbing_skill, :free],
+    [
+      'How many years has your eggyolk been rockclimbing?', rockclimbing_skill, :range,
+      [[0, 2], [3, 5], [6, safe_maximum]],
+      [
+        ['Has your eggyolk taken lessons?', rockclimbing_skill, :free],
+        [
+          'How does your egg prepare for rockclimbing?', rockclimbing_skill, :dropdown,
+          ['Hardboiled', 'Scrambled', 'Overeasy'], no_dependents
+        ],
+        [
+          'How many hours a day does your eggyolk spend rockclimbing?', rockclimbing_skill, :range,
+          [[0, 4], [5, 8], [0, 24]],
+          [
+            ['Describe your eggyolk\'s work-life balance.', rockclimbing_skill, :free],
+            ['Is your eggyolk often exhausted?', rockclimbing_skill, :dropdown, ['Yes', 'No'], no_dependents],
+            nil
+          ]
+        ]
+      ]
+    ],
+    [
+      'Does your eggyolk have any allergies?', eggyolk_information, :dropdown,
+      ['Yes', 'No'],
+      [['List any foods your eggyolk may be allergic to.', eggyolk_information, :free], nil] 
+    ],
+    ['What is your eggyolk\'s budget on rockclimbing?', eggyolk_information, :range,
+      [[0, 100], [101, 500], [501, safe_maximum]],
+      [nil, nil, ['Is your eggyolk employed?', eggyolk_information, :dropdown, ['Yes', 'No'], no_dependents]]
+    ],
+    ['Briefly describe how your eggyolk discovered rockclimbing.', eggyolk_information, :free],
+    ['Explain why your eggyolk enjoys rockclimbing, if applicable.', eggyolk_information, :free],
+    ['What kind of shoes does your eggyolk use when rockclimbing?', eggyolk_information, :dropdown,
+      ['Laces', 'Velcro', 'Slipper'], no_dependents
+    ],
+    ['Which kind of rockclimbing does your eggyolk engage in?', eggyolk_information, :dropdown,
+      ['Bouldering', 'Top Rope Climbing', 'Mountaineering'], no_dependents
+    ],
+    ['How many shoes does your eggyolk own?', eggyolk_information, :range, [[0, 10]], no_dependents],
+    ['What size shoe is your eggyolk?', eggyolk_information, :range, [[0, 20]], no_dependents]
+  ]
+end
 
 # Questions
 # -----
 # FORMAT
 # [<text>, <category>, <type>, <array of options>, <array of dependents (or nils)>]
-
-no_dependents = Array.new(3, nil);
-safe_maximum = 2**31 - 1
-
-large_cube_retail_questions = [
-  ['Describe the kind of cubes you enjoy most.', cube_facts, :free],
-  ['How many cubes do you currently have in your building?', cube_facts, :free],
-  ['Please provide your three desired cube colors.', cube_facts, :free],
-  ['Who manufactures your cubes?', cube_facts, :dropdown, 
-    %w(Apple Google Samsung), no_dependents],
-  ['During which time slot are you available for a cube inspection?', cube_facts, :dropdown,
-    ['12:00-1:00 PM', '1:00-2:00 PM', '2:00-3:00 PM'], no_dependents],
-  ['What model are your cubes?', cube_facts, :dropdown,
-    ['Model T', 'Corolla', 'Leaf'], no_dependents],
-  ['Please specify the amount of faces your cube has.', cube_facts, :range,
-    [[0, 6]], no_dependents],
-  ['How many corners does your cube have?', cube_facts, :range,
-    [[0, 8]], no_dependents],
-  ['Please evaluate your cube on a scale of 1-10: 1 = Strongly Disagree, 10 = Strongly Agree', cube_care, :range,
-    [[0, 10]], no_dependents],
-  [
-    'Do you love your cube?', cube_care, :dropdown,
-    ['Yes.', 'Not really'],
-    [[
-      'How many times a day do you tell your cube that you love it?', cube_care, :range,
-      [[0, 3], [4, 7], [8, 10]],
-      [
-        [ 'List some ways you can spend more time with your cube.', cube_care, :free ],
-        [ 'What has been your favorite reaction to affection shown towards your cube?', cube_care, :free ],
-        [ 'Does your cube enjoy the attention?', cube_care, :dropdown, ['Yes', 'No'], [nil, nil] ]
-      ]
-    ], nil]
-  ]
-]
-
-rockclimbing_eggyolk_inc_questions = [
-  ['Please provide the name of the rockclimbing gym of your eggyolk\'s choice.', rockclimbing_skill, :free],
-  [
-    'How many years has your eggyolk been rockclimbing?', rockclimbing_skill, :range,
-    [[0, 2], [3, 5], [6, safe_maximum]],
-    [
-      ['Has your eggyolk taken lessons?', rockclimbing_skill, :free],
-      [
-        'How does your egg prepare for rockclimbing?', rockclimbing_skill, :dropdown,
-        ['Hardboiled', 'Scrambled', 'Overeasy'], no_dependents
-      ],
-      [
-        'How many hours a day does your eggyolk spend rockclimbing?', rockclimbing_skill, :range,
-        [[0, 4], [5, 8], [0, 24]],
-        [
-          ['Describe your eggyolk\'s work-life balance.', rockclimbing_skill, :free],
-          ['Is your eggyolk often exhausted?', rockclimbing_skill, :dropdown, ['Yes', 'No'], no_dependents],
-          nil
-        ]
-      ]
-    ]
-  ],
-  [
-    'Does your eggyolk have any allergies?', eggyolk_information, :dropdown,
-    ['Yes', 'No'],
-    [['List any foods your eggyolk may be allergic to.', eggyolk_information, :free], nil] 
-  ],
-  ['What is your eggyolk\'s budget on rockclimbing?', eggyolk_information, :range,
-    [[0, 100], [101, 500], [501, safe_maximum]],
-    [nil, nil, ['Is your eggyolk employed?', eggyolk_information, :dropdown, ['Yes', 'No'], no_dependents]]
-  ],
-  ['Briefly describe how your eggyolk discovered rockclimbing.', eggyolk_information, :free],
-  ['Explain why your eggyolk enjoys rockclimbing, if applicable.', eggyolk_information, :free],
-  ['What kind of shoes does your eggyolk use when rockclimbing?', eggyolk_information, :dropdown,
-    ['Laces', 'Velcro', 'Slipper'], no_dependents
-  ],
-  ['Which kind of rockclimbing does your eggyolk engage in?', eggyolk_information, :dropdown,
-    ['Bouldering', 'Top Rope Climbing', 'Mountaineering'], no_dependents
-  ],
-  ['How many shoes does your eggyolk own?', eggyolk_information, :range, [[0, 10]], no_dependents],
-  ['What size shoe is your eggyolk?', eggyolk_information, :range, [[0, 20]], no_dependents]
-]
 
 def generate_question(question, building_type, parent_option=nil)
   if question.nil?
@@ -144,24 +146,25 @@ def generate_question(question, building_type, parent_option=nil)
   end
 end
 
-large_cube_retail_questions.each_with_index do |q, i|
-  print("\rCreating #{large_cube_retail.name}"\
-  " Question #{i + 1}/#{large_cube_retail_questions.length}...")
-  generate_question(q, large_cube_retail)
+def create_questions
+  $large_cube_retail_questions.each_with_index do |q, i|
+    print("\rCreating #{$large_cube_retail.name}"\
+    " Question #{i + 1}/#{$large_cube_retail_questions.length}...")
+    generate_question(q, $large_cube_retail)
+  end
+
+  print("\n")
+
+  $rockclimbing_eggyolk_inc_questions.each_with_index do |q, i|
+    print("\rCreating #{$rockclimbing_eggyolk_inc.name}"\
+    " Question #{i + 1}/#{$rockclimbing_eggyolk_inc_questions.length}...")
+    generate_question(q, $rockclimbing_eggyolk_inc)
+  end
+
+  print("\n")
 end
 
-print("\n")
-
-rockclimbing_eggyolk_inc_questions.each_with_index do |q, i|
-  print("\rCreating #{rockclimbing_eggyolk_inc.name}"\
-  " Question #{i + 1}/#{rockclimbing_eggyolk_inc_questions.length}...")
-  generate_question(q, rockclimbing_eggyolk_inc)
-end
-
-print("\n")
-
-# RMI Users
-people = [
+$people = [
 ['Test', 'RMI', 'rmi@test.com', '18005558888', 'password'],
 ['Eleanore', 'Donnelly', 'raleigh.hammes@berkeley.edu', '16877036527', '^Vbf=Dtst('],
 ['Orland', 'Johns', 'laurence.spence@berkeley.edu', '18451135957', '}jylKd71Z4n-^Gh'],
@@ -215,7 +218,6 @@ people = [
 ['Merle', 'Effertz', 'barrows.ona@berkeley.edu', '18889991010', 'CXl+`q6sEV3igp']
 ]
 
-users_per_type = people.length / 3
 def person(p)
   {
     first_name: p[0],
@@ -227,32 +229,37 @@ def person(p)
   }
 end
 
-rmi_users = people[0..1 * users_per_type].each_with_index.map do |p, i|
-  print("\rCreating RMI User #{i}/#{users_per_type}...")
-  RmiUser.create(person(p))
-end
+def create_users
+  users_per_type = $people.length / 3
 
-print("\n")
+  # RMI Users
+  $rmi_users = $people[0..1 * users_per_type].each_with_index.map do |p, i|
+    print("\rCreating RMI User #{i}/#{users_per_type}...")
+    RmiUser.create(person(p))
+  end
 
-# Asset Manager Users
-asset_managers = people[1 * users_per_type..2 * users_per_type].each_with_index.map do |p, i|
-  print("\rCreating Asset Manager #{i}/#{users_per_type}...")
-  AssetManager.create(person(p))
-end
+  print("\n")
 
-print("\n")
+  # Asset Manager Users
+  $asset_managers = $people[1 * users_per_type..2 * users_per_type].each_with_index.map do |p, i|
+    print("\rCreating Asset Manager #{i}/#{users_per_type}...")
+    AssetManager.create(person(p))
+  end
 
-# Building Operator Users
-building_operators = people[2 * users_per_type..3 * users_per_type].each_with_index.map do |p, i|
-  print("\rCreating Building Operator #{i}/#{users_per_type}...")
-  BuildingOperator.create(person(p))
+  print("\n")
+
+  # Building Operator Users
+  $building_operators = $people[2 * users_per_type..3 * users_per_type].each_with_index.map do |p, i|
+    print("\rCreating Building Operator #{i}/#{users_per_type}...")
+    BuildingOperator.create(person(p))
+  end
 end
 
 # Locations
 # -----
 # FORMAT
 # [<name>, <address>, <city>, <state>, <zip>]
-addresses = [
+$addresses = [
   ['Unit 1', '2650 Durant Ave', 'Berkeley', :California, 94704],
   ['Northside Cafe', '1878 Euclid Ave', 'Berkeley', :California, 94709],
   ['MLK Student Union', '2560 Bancroft Way', 'Berkeley', :California, 94704],
@@ -281,37 +288,48 @@ def generate_location(l)
 end
 
 # Portfolios
-portfolios = asset_managers.map do |a|
-  Portfolio.create!({ name: a.first_name + "'s Portfolio", asset_manager: a })
-end
-
-# Buildings
-print("\n")
-Array(0...portfolios.length).each_with_index do |i, portfolio_index|
-  print("Creating Portfolio #{portfolio_index}/#{portfolios.length - 1}")
-  portfolio = portfolios[i]
-  asset_manager = portfolio.asset_manager
-
-  print("\n")
-  Array(0...addresses.length).each_with_index do |j, building_index|
-    print("\r- Creating Building #{building_index}/#{addresses.length - 1}")
-    location = generate_location(addresses[j])
-    building = Building.new({
-      portfolio: portfolio,
-      name: location[:name],
-      address: location[:address],
-      city: location[:city],
-      state: location[:state],
-      zip: location[:zip]
-    })
-
-    if i.even?
-      building.building_type = large_cube_retail
-    else
-      building.building_type = rockclimbing_eggyolk_inc
-    end
-
-    building.save!
+def create_portfolios
+  $portfolios = $asset_managers.map do |a|
+    Portfolio.create!({ name: a.first_name + "'s Portfolio", asset_manager: a })
   end
   print("\n")
 end
+
+# Buildings
+def create_buildings
+  Array(0...$portfolios.length).each_with_index do |i, portfolio_index|
+    print("Creating Portfolio #{portfolio_index}/#{$portfolios.length - 1}")
+    portfolio = $portfolios[i]
+    asset_manager = portfolio.asset_manager
+
+    print("\n")
+    Array(0...$addresses.length).each_with_index do |j, building_index|
+      print("\r- Creating Building #{building_index}/#{$addresses.length - 1}")
+      location = generate_location($addresses[j])
+      building = Building.new({
+        portfolio: portfolio,
+        name: location[:name],
+        address: location[:address],
+        city: location[:city],
+        state: location[:state],
+        zip: location[:zip]
+      })
+
+      if i.even?
+        building.building_type = $large_cube_retail
+      else
+        building.building_type = $rockclimbing_eggyolk_inc
+      end
+
+      building.save!
+    end
+    print("\n")
+  end
+end
+
+create_building_types
+create_categories
+create_questions
+create_users
+create_portfolios
+create_buildings


### PR DESCRIPTION
For testing purposes:

- Run `bin/rails db:seed` (will also run on `rails db:reset` with creation + migration)

All 15 buildings of each asset manager (inside their respective portfolios) have the same fixed set of locations. See comments for adding more locations, buildings, or questions.

This branch **does not** include the migration updates for refactoring the location details directly into the building model, as in #48. See #50 or `11+42/testing` branch to test with these changes merged together.

This branch **does not** include the fixes in #53, so `parent_option_id`s may be inaccurate when testing on this branch. 

Resolves #11.