### PR TITLE
Fix portfolio API controller strong params

### DIFF
--- a/app/controllers/api/portfolios_controller.rb
+++ b/app/controllers/api/portfolios_controller.rb
@@ -33,12 +33,12 @@ class Api::PortfoliosController < ApplicationController
   end
 
   private
+
   def portfolio_params
     params.require(:portfolio)
-        .permit(
+          .permit(
             :name,
-            :asset_manager,
-            :buildings
-        )
+            :asset_manager_id
+          )
   end
 end


### PR DESCRIPTION
Change params to column names (like asset_manager_id) instead of model names (asset_manager)