### PR TITLE
Mailer for building operators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'annotate'
+  # Opens email previews in browser instead of sending them
+  gem "letter_opener"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,10 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -227,6 +231,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   jbuilder (~> 2.5)
+  letter_opener
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   puma (~> 3.7)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'info@rmi.org'
   layout 'mailer'
 end

--- a/app/mailers/building_operator_mailer.rb
+++ b/app/mailers/building_operator_mailer.rb
@@ -1,7 +1,15 @@
 class BuildingOperatorMailer < ApplicationMailer
-  # Gets sent to building operators when they are delegated questions but haven't been onboarded yet
+  # Gets sent when building operator is delegated questions but *hasn't been onboarded yet*
   def new_user_delegated_email(user)
     @user = user
+
+    # Manually generate a password reset link
+    raw, enc = Devise.token_generator.generate(BuildingOperator, :reset_password_token)
+    user.reset_password_token = enc
+    user.reset_password_sent_at = Time.now.utc
+    user.save
+    @url = edit_building_operator_password_url(@user, reset_password_token: raw)
+
     email_with_name = %("#{@user.first_name} #{@user.last_name}" <#{@user.email}>)
     mail(to: email_with_name, subject: 'Welcome to RMI! You have new building tasks pending')
   end

--- a/app/mailers/building_operator_mailer.rb
+++ b/app/mailers/building_operator_mailer.rb
@@ -1,16 +1,29 @@
 class BuildingOperatorMailer < ApplicationMailer
-  # Gets sent when building operator is delegated questions but *hasn't been onboarded yet*
+  # Gets sent when a building operator is delegated questions but *hasn't been onboarded yet*
   def new_user_delegated_email(user)
     @user = user
 
     # Manually generate a password reset link
-    raw, enc = Devise.token_generator.generate(BuildingOperator, :reset_password_token)
-    user.reset_password_token = enc
-    user.reset_password_sent_at = Time.now.utc
-    user.save
+    raw, encrypted = Devise.token_generator.generate(BuildingOperator, :reset_password_token)
+    @user.reset_password_token = encrypted
+    @user.reset_password_sent_at = Time.now.utc
+    @user.save
     @url = edit_building_operator_password_url(@user, reset_password_token: raw)
 
-    email_with_name = %("#{@user.first_name} #{@user.last_name}" <#{@user.email}>)
-    mail(to: email_with_name, subject: 'Welcome to RMI! You have new building tasks pending')
+    mail_to @user, subject: 'Welcome to RMI! You have new building tasks pending'
+  end
+
+  # Gets sent when an existing building operator is delegated more questions
+  def existing_user_delegated_email(user)
+    @user = user
+    @url = building_operator_url(@user)
+    mail_to @user, subject: 'You have been assigned new building tasks'
+  end
+
+  private
+
+  def mail_to(user, subject)
+    email_with_name = %("#{user.first_name} #{user.last_name}" <#{user.email}>)
+    mail(to: email_with_name, subject: subject[:subject])
   end
 end

--- a/app/mailers/building_operator_mailer.rb
+++ b/app/mailers/building_operator_mailer.rb
@@ -1,0 +1,8 @@
+class BuildingOperatorMailer < ApplicationMailer
+  # Gets sent to building operators when they are delegated questions but haven't been onboarded yet
+  def new_user_delegated_email(user)
+    @user = user
+    email_with_name = %("#{@user.first_name} #{@user.last_name}" <#{@user.email}>)
+    mail(to: email_with_name, subject: 'Welcome to RMI! You have new building tasks pending')
+  end
+end

--- a/app/models/building_operator.rb
+++ b/app/models/building_operator.rb
@@ -26,6 +26,8 @@ class BuildingOperator < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  after_create :send_onboarding_email
+
   has_many :answers
 
   has_many :building_assignments, foreign_key: :building_operator_id, class_name: "BuildingOperatorAssignment"
@@ -35,4 +37,10 @@ class BuildingOperator < ApplicationRecord
   # email validation with regex
   validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, :on => :create
   validates :phone, :presence => true, :numericality => true, :length => { :minimum => 10, :maximum => 15}
+
+  # New building operator accounts are only created when an asset manager delegates a question to them,
+  # so send an onboarding email telling them they have new questions.
+  def send_onboarding_email
+    BuildingOperatorMailer.new_user_delegated_email(self).deliver_now
+  end
 end

--- a/app/views/building_operator_mailer/existing_user_delegated_email.html.erb
+++ b/app/views/building_operator_mailer/existing_user_delegated_email.html.erb
@@ -1,0 +1,9 @@
+<p>
+  Dear <%= @user.first_name %>,
+</p>
+<p>
+  You have been assigned new questions to fill out regarding your buildings.
+</p>
+<p>
+  <%= link_to('Click here to access your RMI dashboard', @url) %>
+</p>

--- a/app/views/building_operator_mailer/existing_user_delegated_email.text.erb
+++ b/app/views/building_operator_mailer/existing_user_delegated_email.text.erb
@@ -1,0 +1,6 @@
+Dear <%= @user.first_name %>,
+
+You have been assigned new questions to fill out regarding your buildings.
+
+Click the link below to access your RMI dashboard:
+<%= @url %>

--- a/app/views/building_operator_mailer/new_user_delegated_email.html.erb
+++ b/app/views/building_operator_mailer/new_user_delegated_email.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<h1>Welcome to RMI, <%= @user.first_name %>!</h1>
+<p>
+  You have been assigned new tasks to fill out.
+</p>
+<p>
+  To login to the site, just follow this link: (URL HERE)
+</p>
+</body>
+</html>

--- a/app/views/building_operator_mailer/new_user_delegated_email.html.erb
+++ b/app/views/building_operator_mailer/new_user_delegated_email.html.erb
@@ -1,15 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-</head>
-<body>
-<h1>Welcome to RMI, <%= @user.first_name %>!</h1>
+<h2>Welcome to RMI, <%= @user.first_name %>!</h2>
 <p>
-  You have been assigned new tasks to fill out.
+  An asset manager would like you to fill out some information regarding your buildings. An account has been created
+  for you on the RMI dashboard, where you can complete and submit questionnaires assigned to you.
 </p>
 <p>
-  <%= link_to('Click here to begin', @url) %>
+  <%= link_to('Please click here to begin', @url) %>
 </p>
-</body>
-</html>

--- a/app/views/building_operator_mailer/new_user_delegated_email.html.erb
+++ b/app/views/building_operator_mailer/new_user_delegated_email.html.erb
@@ -9,7 +9,7 @@
   You have been assigned new tasks to fill out.
 </p>
 <p>
-  To login to the site, just follow this link: (URL HERE)
+  <%= link_to('Click here to begin', @url) %>
 </p>
 </body>
 </html>

--- a/app/views/building_operator_mailer/new_user_delegated_email.text.erb
+++ b/app/views/building_operator_mailer/new_user_delegated_email.text.erb
@@ -1,0 +1,8 @@
+Welcome to RMI, <%= @user.first_name %>!
+===============================================
+
+You have been assigned new tasks to fill out.
+
+To login to the site, just follow this link: (URL HERE)
+
+Thanks for joining and have a great day!

--- a/app/views/building_operator_mailer/new_user_delegated_email.text.erb
+++ b/app/views/building_operator_mailer/new_user_delegated_email.text.erb
@@ -1,8 +1,8 @@
 Welcome to RMI, <%= @user.first_name %>!
 ===============================================
 
-You have been assigned new tasks to fill out.
+An asset manager would like you to fill out some information regarding your buildings. An account has been created
+for you on the RMI dashboard, where you can complete and submit questionnaires assigned to you.
 
-To login to the site, just follow this link: (URL HERE)
-
-Thanks for joining and have a great day!
+Please click the link below to begin:
+<%= @url %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,13 +26,15 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  config.action_mailer.perform_deliveries = true
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
 
   # Saves emails in ActionMailer::Base.deliveries instead of actually sending them
-  config.action_mailer.delivery_method = :test
+  config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
-  # Saves emails in ActionMailer::Base.deliveries instead of actually sending them
+  # Opens email previews in browser instead of actually sending them
   config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Saves emails in ActionMailer::Base.deliveries instead of actually sending them
+  config.action_mailer.delivery_method = :test
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Saves emails in ActionMailer::Base.deliveries instead of actually sending them
   config.action_mailer.delivery_method = :letter_opener
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :buildings, only: [:show]
   resources :portfolios, only: [:show]
   resources :asset_managers, only: [:show]
+  resources :building_operators, only: [:show]
 
   namespace :api, defaults: { format: :json } do
     resources :portfolios, only: [:create, :update, :show, :index]

--- a/test/mailers/building_operator_mailer_test.rb
+++ b/test/mailers/building_operator_mailer_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BuildingOperatorMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/building_operator_mailer_preview.rb
+++ b/test/mailers/previews/building_operator_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/building_operator_mailer
+class BuildingOperatorMailerPreview < ActionMailer::Preview
+  def new_user_delegated_email
+    BuildingOperatorMailer.new_user_delegated_email(BuildingOperator.first)
+  end
+end

--- a/test/mailers/previews/building_operator_mailer_preview.rb
+++ b/test/mailers/previews/building_operator_mailer_preview.rb
@@ -3,4 +3,8 @@ class BuildingOperatorMailerPreview < ActionMailer::Preview
   def new_user_delegated_email
     BuildingOperatorMailer.new_user_delegated_email(BuildingOperator.first)
   end
+
+  def existing_user_delegated_email
+    BuildingOperatorMailer.existing_user_delegated_email(BuildingOperator.first)
+  end
 end


### PR DESCRIPTION
Create a mailer for:
- Onboarding new building operators when they are delegated questions
- Notifying existing building operators when they receive new questions

Links within the emails will redirect the user to the appropriate page, either password reset (if new user) or the profile page (if existing user).

_NOTE: BuildingOperatorsController currently does not exist, so the profile page for existing users will show an error -- however, the url is still correct._

Resolves #66 