### PR TITLE
Allow answers to include attachment using paperclip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,10 @@ gem 'rubyzip'
   # Generates seed information
 gem 'faker', '~> 1.8.4'
 
+# AWS upload
+gem 'paperclip'
+gem 'aws-sdk', '~> 2.3'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -33,6 +33,7 @@ class Api::AnswersController < ApplicationController
     params.require(:answer)
           .permit(
             :text,
+            :attachment,
             :building_id,
             :question_id,
             :user_id,

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,15 +2,19 @@
 #
 # Table name: answers
 #
-#  id          :integer          not null, primary key
-#  text        :text             default("")
-#  building_id :integer
-#  question_id :integer
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  status      :integer
-#  user_type   :string
-#  user_id     :integer
+#  id                      :integer          not null, primary key
+#  text                    :text             default("")
+#  building_id             :integer
+#  question_id             :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  status                  :integer
+#  user_type               :string
+#  user_id                 :integer
+#  attachment_file_name    :string
+#  attachment_content_type :string
+#  attachment_file_size    :integer
+#  attachment_updated_at   :datetime
 #
 
 class Answer < ApplicationRecord
@@ -20,8 +24,11 @@ class Answer < ApplicationRecord
   belongs_to :question
   belongs_to :user, polymorphic: true
 
+  has_attached_file :attachment
+
   validates :text, presence: true
   validate :valid_email, on: :update
+  validate :attachment, :size => { :in => 0..2.megabytes }
 
   # Set default status to unanswered
   after_initialize do

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -27,8 +27,8 @@ class Answer < ApplicationRecord
   has_attached_file :attachment
 
   validates :text, presence: true
+  validates_with AttachmentSizeValidator, attributes: :attachment, less_than: 2.megabytes
   validate :valid_email, on: :update
-  validate :attachment, :size => { :in => 0..2.megabytes }
 
   # Set default status to unanswered
   after_initialize do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,4 +62,16 @@ Rails.application.configure do
   # Devise setup
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  # AWS credentials for paperclip upload
+  config.paperclip_defaults = {
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV.fetch('S3_BUCKET_NAME'),
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+      s3_region: ENV.fetch('AWS_REGION'),
+    }
+  }
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,5 +92,16 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # AWS credentials for paperclip
+  config.paperclip_defaults = {
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV.fetch('S3_BUCKET_NAME'),
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+      s3_region: ENV.fetch('AWS_REGION'),
+    }
+  }
+
 
 end

--- a/db/migrate/20180210020810_add_paperclip_to_answers.rb
+++ b/db/migrate/20180210020810_add_paperclip_to_answers.rb
@@ -1,0 +1,5 @@
+class AddPaperclipToAnswers < ActiveRecord::Migration[5.1]
+  def change
+    add_attachment :answers, :attachment
+  end
+end


### PR DESCRIPTION
Closes #131 

This PR uses paperclip gem to support attachments with Answer model. @ethanlee16 Where should the AWS S3 credentials be kept?

-- Model:
Run db migration, new db fields are added!
Currently only simple validation of file size less than 2MB. Optional.

-- API controller
Permits attachment as an optional argument.

-- config/environments.rb
Add several S3 related fields for environment variables.

Testing: I am not sure how to test API interfaces... Actually I have little idea how things should behave at this time...