### PR TITLE
Hotfix: performance improvements for building initial state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'webpacker'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 gem 'active_model_serializers', '~> 0.10.0'
+gem 'bullet', group: 'development'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       rack (>= 0.9.0)
     bindex (0.5.0)
     builder (3.2.3)
+    bullet (5.7.5)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11.0)
     byebug (9.1.0)
     cancancan (2.0.0)
     capybara (2.15.1)
@@ -245,6 +248,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    uniform_notifier (1.11.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -271,6 +275,7 @@ DEPENDENCIES
   annotate
   aws-sdk (~> 2.3)
   better_errors
+  bullet
   byebug
   cancancan (~> 2.0)
   capybara (~> 2.13)

--- a/app/models/building_operator.rb
+++ b/app/models/building_operator.rb
@@ -55,11 +55,9 @@ class BuildingOperator < ApplicationRecord
 
   def buildings
     buildings = Set.new []
-    d = delegations.includes(answer: :building).load.to_a
+    d = delegations.where(status: 'active').includes(answer: :building).load.to_a
     d.each do |delegation|
-      if delegation.status == 'active'
-        buildings << delegation.answer.building
-      end
+      buildings << delegation.answer.building
     end
     buildings.to_a
   end
@@ -89,12 +87,11 @@ class BuildingOperator < ApplicationRecord
     # Returns
     # questions: array of question objects that are accessible to read
     questions = []
-    d = delegations.includes(
+    d = delegations.where(status: 'active').includes(
       answer: [:building, question: [{ parent_option: :question }, :dropdown_options, :range_options ]]
     ).load.to_a
     d.each do |delegation|
-      if delegation.status == 'active' &&
-        delegation.answer.building.id == building_id
+      if delegation.answer.building.id == building_id
         question = delegation.answer.question
         questions << question
         questions = questions + Question.get_all_parents(question)
@@ -122,12 +119,11 @@ class BuildingOperator < ApplicationRecord
     # Returns
     # questions: array of question objects that are accessible to read
     questions = Set.new
-    d = delegations.includes(
+    d = delegations.where(status: 'active').includes(
       answer: [:building, question: [{ parent_option: :question }, :dropdown_options, :range_options ]]
     ).load.to_a
     d.each do |delegation|
-      if delegation.status == 'active' &&
-        building_ids.include?(delegation.answer.building.id)
+      if building_ids.include?(delegation.answer.building.id)
         question = delegation.answer.question
         questions << question
         questions = questions + Question.get_all_parents(question)

--- a/app/serializers/building_serializer.rb
+++ b/app/serializers/building_serializer.rb
@@ -32,11 +32,18 @@ class BuildingSerializer < ActiveModel::Serializer
   end
 
   def questions
+    questions = object.questions.ids
+    delegations_for_building = scope[:delegations].select do |d|
+      d.answer.building.id == object.id
+    end
+    ids_from_delegations = delegations_for_building.map { |d| d.answer.question.id }
     _questions =
       if scope[:user_type] == 'BuildingOperator'
-        BuildingOperator.find(scope[:user_id]).questions_by_building(object.id)
+        scope[:questions].select do |q|
+          ids_from_delegations.include?(q.id)
+        end
       else
-        object.questions
+        Building.includes(:building_type).find(object.id).questions
       end
     _questions.each_with_object({}) do |q, hsh|
       hsh[q.id] = QuestionSerializer.new(q).as_json

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,9 @@ Rails.application.configure do
     }
   }
 
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.rails_logger = true
+  end
+
 end


### PR DESCRIPTION
I got a little tired of testing on 45-second response times and took some time to take an _initial_ stab at this (much more work to be done, these are just some first pass optimizations to make loading bearable):

**What this PR does:** 
* Uses `.includes` and some serializer scope variables for building operators to take load times down to 5 seconds on a fresh start of the server
* Adds [`bullet`](https://github.com/flyerhzm/bullet) in development environments, which will log messages if there are ways in the future that you can use `.includes` or eager loading to eliminate "N+1" queries

**What this PR does not do (will file as a tech debt issue later)**:
* Potentially restructuring initial state so that all questions get into `window.INITIAL_STATE.questions` instead of inside buildings? Perform filtering on client-side? We waste some load time doing this on the backend (although the SQL result is cached, recreating the ActiveRecord Relation/Model takes time).
* Fixing N+1 queries remaining for question options, undetected by Bullet
* Cross-applying fixes to the less-evidently-inefficient Asset Manager initial state generation
