### PR TITLE
Hotfix: check weak equality for null, not falsy values

### DIFF
--- a/app/javascript/packs/containers/AnswerModeContainer.jsx
+++ b/app/javascript/packs/containers/AnswerModeContainer.jsx
@@ -16,7 +16,7 @@ class AnswerModeContainer extends React.Component {
       <div>
         {this.props.questions.map((question) => {
           // Only display non-dependent questions initially
-          if (!question.parent_option_id) {
+          if (question.parent_option_id == null) {
             return (<QuestionContainer mode="answer"
                               key={question.id}
                               building_id={this.props.building.id}


### PR DESCRIPTION
We should check for `null/undefined`, because the ID could be 0 (falsy).