### PR TITLE
Add Flow type definitions and build process

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,8 @@
       }
     ],
     "react",
-    "stage-0"
+    "stage-0",
+    "flow"
   ],
   "plugins": [
     "react-hot-loader/babel",

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,12 @@
+[ignore]
+
+[include]
+
+[libs]
+./node_modules/fbjs/flow/lib
+
+[lints]
+
+[options]
+
+[strict]

--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 
 [libs]
 ./node_modules/fbjs/flow/lib
+./flow-typed/
 
 [lints]
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,7 +73,6 @@ module ApplicationHelper
           .load.to_a,
        }
       ),
-      userType: 'BuildingOperator',
       contacts: contacts,
       categories: current_building_operator.categories,
       userType: current_building_operator.class.name,

--- a/app/javascript/packs/containers/BuildingListContainer.jsx
+++ b/app/javascript/packs/containers/BuildingListContainer.jsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react';
 
 import * as BuildingActions from '../actions/buildings';

--- a/app/javascript/packs/containers/BuildingListContainer.jsx
+++ b/app/javascript/packs/containers/BuildingListContainer.jsx
@@ -1,3 +1,5 @@
+/* @flow */
+
 import React from 'react';
 
 import * as BuildingActions from '../actions/buildings';

--- a/app/javascript/packs/containers/PortfolioContainer.jsx
+++ b/app/javascript/packs/containers/PortfolioContainer.jsx
@@ -8,14 +8,12 @@ import { getBuildingsByPortfolio } from '../selectors/buildingsSelector';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import type { Match } from 'react-router-dom';
+import type { Building } from 'rmi';
 
 type Props = {
-  buildings: {
-    id: {
-      name: string
-    }
-  },
-  f: number
+  buildings: [ Building ],
+  match: Match
 };
 
 

--- a/app/javascript/packs/containers/PortfolioContainer.jsx
+++ b/app/javascript/packs/containers/PortfolioContainer.jsx
@@ -12,13 +12,17 @@ import type { Match } from 'react-router-dom';
 import type { Building } from 'rmi';
 
 type Props = {
-  buildings: [ Building ],
-  match: Match
+  buildings: Array<Building>,
+  match: Match,
 };
-
 
 class PortfolioContainer extends React.Component<Props> {
   render() {
+    let portfolioId: ?string = this.props.match.params.pId;
+    if (typeof portfolioId !== 'string') {
+      portfolioId = '';
+    }
+
     return (<div>
       <h2>Portfolio</h2>
       <a href={`download/${this.props.match.params.pId}`}>Download as CSV</a>

--- a/app/javascript/packs/containers/PortfolioContainer.jsx
+++ b/app/javascript/packs/containers/PortfolioContainer.jsx
@@ -1,3 +1,5 @@
+/* @flow */
+
 import React from 'react';
 
 import * as BuildingActions from '../actions/buildings';
@@ -7,7 +9,17 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-class PortfolioContainer extends React.Component {
+type Props = {
+  buildings: {
+    id: {
+      name: string
+    }
+  },
+  f: number
+};
+
+
+class PortfolioContainer extends React.Component<Props> {
   render() {
     return (<div>
       <h2>Portfolio</h2>

--- a/app/javascript/packs/containers/PortfolioContainer.jsx
+++ b/app/javascript/packs/containers/PortfolioContainer.jsx
@@ -25,7 +25,7 @@ class PortfolioContainer extends React.Component<Props> {
 
     return (<div>
       <h2>Portfolio</h2>
-      <a href={`download/${this.props.match.params.pId}`}>Download as CSV</a>
+      <a href={`download/${portfolioId}`}>Download as CSV</a>
       <hr />
       <div className="building__container">
       {this.props.buildings.map(building => {

--- a/app/javascript/packs/selectors/answersSelector.js
+++ b/app/javascript/packs/selectors/answersSelector.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type { Answer } from 'rmi';
+import type { Answer, Question } from 'rmi';
 
 export function getAnswerForQuestionAndBuilding(
   questionId: string,
@@ -15,7 +15,11 @@ export function getAnswerForQuestionAndBuilding(
 // so we should not render how many questions are remaining for a building
 //## if no questions are provided, the building did not have any questions for the users so they have no questions
 //to answer for that building
-export function getRemainingAnswersforCategory(questions, buildingId, state) {
+export function getRemainingAnswersforCategory(
+  questions: Array<Question>,
+  buildingId: number,
+  state: any
+): number {
   return questions.reduce((count, question) => {
     let answer = state.buildings[buildingId].answers[question.id];
     if (!answer || !answer.text.trim() && !answer.attachment_file_name) {

--- a/app/javascript/packs/selectors/answersSelector.js
+++ b/app/javascript/packs/selectors/answersSelector.js
@@ -1,6 +1,14 @@
-export function getAnswerForQuestionAndBuilding(questionId, buildingId, state) {
-  return state.buildings[buildingId].answers[questionId]
-}
+/* @flow */
+
+import type { Answer } from 'rmi';
+
+export function getAnswerForQuestionAndBuilding(
+  questionId: string,
+  buildingId: string, 
+  state: any
+): Answer {
+  return state.buildings[buildingId].answers[questionId];
+};
 
 //##returns (from the questions provided) how many are remaining to answer
 //##if no buildingId is provided, we are not viewing a specific building
@@ -16,4 +24,3 @@ export function getRemainingAnswersforCategory(questions, buildingId, state) {
     return count;
   }, 0);
 }
-

--- a/app/javascript/packs/selectors/buildingsSelector.js
+++ b/app/javascript/packs/selectors/buildingsSelector.js
@@ -18,7 +18,7 @@ export function getBuildings(state: any): {
   return state.buildings
 };
 
-export function getBuildingById(buildingId, state) {
+export function getBuildingById(buildingId: number, state: any): Building {
   return state.buildings[buildingId]
 
 }

--- a/app/javascript/packs/selectors/buildingsSelector.js
+++ b/app/javascript/packs/selectors/buildingsSelector.js
@@ -1,4 +1,10 @@
-export function getBuildingsByPortfolio(portfolioId, state) {
+/* @flow */
+import type { Building } from 'rmi';
+
+export function getBuildingsByPortfolio(
+  portfolioId: string,
+  state: any
+): Array<Building> {
   return Object.keys(state.buildings).filter((buildingId) => {
     return state.buildings[buildingId].portfolio_id == portfolioId;
   }).map((buildingId) => {
@@ -6,7 +12,9 @@ export function getBuildingsByPortfolio(portfolioId, state) {
   });
 };
 
-export function getBuildings(state) {
+export function getBuildings(state: any): {
+  [buildingId: string]: Building
+} {
   return state.buildings
 };
 

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,6 +1,7 @@
 const environment = require('./environment');
 const webpack = require('webpack');
 const FriendlyErrorsWebpack = require('friendly-errors-webpack-plugin');
+const FlowBabelWebpackPlugin = require('flow-babel-webpack-plugin');
 
 const config = environment.toWebpackConfig();
 config.devtool = 'cheap-module-eval-source-map';
@@ -8,6 +9,7 @@ config.devtool = 'cheap-module-eval-source-map';
 config.devServer.quiet = true;
 
 config.plugins.push(new FriendlyErrorsWebpack());
+config.plugins.push(new FlowBabelWebpackPlugin());
 
 config.output.filename =  '[name].bundle.js';
 

--- a/flow-typed/npm/react-router-dom_v4.x.x.js
+++ b/flow-typed/npm/react-router-dom_v4.x.x.js
@@ -1,0 +1,158 @@
+// flow-typed signature: 7ef7e99bfa7953a438470755d51dc345
+// flow-typed version: 107feb8c45/react-router-dom_v4.x.x/flow_>=v0.53.x
+
+declare module "react-router-dom" {
+  declare export class BrowserRouter extends React$Component<{
+    basename?: string,
+    forceRefresh?: boolean,
+    getUserConfirmation?: GetUserConfirmation,
+    keyLength?: number,
+    children?: React$Node
+  }> {}
+
+  declare export class HashRouter extends React$Component<{
+    basename?: string,
+    getUserConfirmation?: GetUserConfirmation,
+    hashType?: "slash" | "noslash" | "hashbang",
+    children?: React$Node
+  }> {}
+
+  declare export class Link extends React$Component<{
+    to: string | LocationShape,
+    replace?: boolean,
+    children?: React$Node
+  }> {}
+
+  declare export class NavLink extends React$Component<{
+    to: string | LocationShape,
+    activeClassName?: string,
+    className?: string,
+    activeStyle?: Object,
+    style?: Object,
+    isActive?: (match: Match, location: Location) => boolean,
+    children?: React$Node,
+    exact?: boolean,
+    strict?: boolean
+  }> {}
+
+  // NOTE: Below are duplicated from react-router. If updating these, please
+  // update the react-router and react-router-native types as well.
+  declare export type Location = {
+    pathname: string,
+    search: string,
+    hash: string,
+    state?: any,
+    key?: string
+  };
+
+  declare export type LocationShape = {
+    pathname?: string,
+    search?: string,
+    hash?: string,
+    state?: any
+  };
+
+  declare export type HistoryAction = "PUSH" | "REPLACE" | "POP";
+
+  declare export type RouterHistory = {
+    length: number,
+    location: Location,
+    action: HistoryAction,
+    listen(
+      callback: (location: Location, action: HistoryAction) => void
+    ): () => void,
+    push(path: string | LocationShape, state?: any): void,
+    replace(path: string | LocationShape, state?: any): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    canGo?: (n: number) => boolean,
+    block(
+      callback: (location: Location, action: HistoryAction) => boolean
+    ): void,
+    // createMemoryHistory
+    index?: number,
+    entries?: Array<Location>
+  };
+
+  declare export type Match = {
+    params: { [key: string]: ?string },
+    isExact: boolean,
+    path: string,
+    url: string
+  };
+
+  declare export type ContextRouter = {|
+    history: RouterHistory,
+    location: Location,
+    match: Match
+  |};
+
+  declare export type GetUserConfirmation = (
+    message: string,
+    callback: (confirmed: boolean) => void
+  ) => void;
+
+  declare type StaticRouterContext = {
+    url?: string
+  };
+
+  declare export class StaticRouter extends React$Component<{
+    basename?: string,
+    location?: string | Location,
+    context: StaticRouterContext,
+    children?: React$Node
+  }> {}
+
+  declare export class MemoryRouter extends React$Component<{
+    initialEntries?: Array<LocationShape | string>,
+    initialIndex?: number,
+    getUserConfirmation?: GetUserConfirmation,
+    keyLength?: number,
+    children?: React$Node
+  }> {}
+
+  declare export class Router extends React$Component<{
+    history: RouterHistory,
+    children?: React$Node
+  }> {}
+
+  declare export class Prompt extends React$Component<{
+    message: string | ((location: Location) => string | boolean),
+    when?: boolean
+  }> {}
+
+  declare export class Redirect extends React$Component<{
+    to: string | LocationShape,
+    push?: boolean
+  }> {}
+
+  declare export class Route extends React$Component<{
+    component?: React$ComponentType<*>,
+    render?: (router: ContextRouter) => React$Node,
+    children?: React$ComponentType<ContextRouter> | React$Node,
+    path?: string,
+    exact?: boolean,
+    strict?: boolean
+  }> {}
+
+  declare export class Switch extends React$Component<{
+    children?: React$Node
+  }> {}
+
+  declare export function withRouter<P>(
+    Component: React$ComponentType<{| ...ContextRouter, ...P |}>
+  ): React$ComponentType<P>;
+
+  declare type MatchPathOptions = {
+    path?: string,
+    exact?: boolean,
+    sensitive?: boolean,
+    strict?: boolean
+  };
+
+  declare export function matchPath(
+    pathname: string,
+    options?: MatchPathOptions | string
+  ): null | Match;
+}

--- a/flow-typed/rmi.js
+++ b/flow-typed/rmi.js
@@ -27,4 +27,21 @@ declare module "rmi" {
     delegation_first_name?: string,
     delegation_last_name?: string
   }
+
+  declare type OptionType = "DropdownOption" | "RangeOption" | "FileOption" | "free";
+
+  declare export class Question {
+    id: number,
+    question_type: OptionType,
+    building_type_id: number,
+    parent_option_type?: OptionType,
+    parent_option_id?: number,
+    category_id: number,
+    text: string,
+    status: "draft" | "published",
+    parameter: string,
+    options: Array<number>,
+    helper_text?: string,
+    unit?: string
+  }
 }

--- a/flow-typed/rmi.js
+++ b/flow-typed/rmi.js
@@ -1,0 +1,30 @@
+declare module "rmi" {
+  declare export class Building {
+    id: number,
+    name: string,
+    portfolio_id: number,
+    building_type_id: number,
+    address: string,
+    city: string,
+    state: string,
+    zip: number,
+    answers: [Answer]
+  }
+
+  declare export class Answer {
+    id: number,
+    text?: string,
+    building_id: number,
+    question_id: number,
+    created_at: string,
+    updated_at: string,
+    selected_option_id?: number,
+    attachment_file_name?: string,
+    attachment_content_type?: string,
+    attachment_file_size?: number,
+    attachment_updated_at?: string,
+    delegation_email?: string,
+    delegation_first_name?: string,
+    delegation_last_name?: string
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "webpack-merge": "^4.1.2"
   },
   "devDependencies": {
+    "babel-preset-flow": "^6.23.0",
     "babel-preset-stage-0": "^6.24.1",
     "css-loader": "^0.28.10",
     "friendly-errors-webpack-plugin": "^1.6.1",
@@ -37,7 +38,9 @@
     "react-hot-loader": "^4.0.0",
     "sass-loader": "^6.0.7",
     "style-loader": "^0.20.2",
-    "webpack-dev-server": "^2.11.2"
+    "webpack-dev-server": "^2.11.2",
+    "flow-babel-webpack-plugin": "^1.1.1",
+    "flow-bin": "^0.67.1"
   },
   "scripts": {
     "lint": "eslint src",


### PR DESCRIPTION
- Updates our Babel config to allow Flow typing and includes a Flow type-checking process to run with our Webpack dev server
- Provides examples in `PortfolioContainer`, `answersSelector`, and `buildingsSelector` for how to retroactively apply Flow types
- Adds initial type definitions for Buildings, Answers, and Questions, to `flow-typed/rmi.js` - where our custom type and class definitions should be stored and exported