### PR TITLE
Allow asset manager to create answers

### DIFF
--- a/app/javascript/packs/containers/OptionsContainer.jsx
+++ b/app/javascript/packs/containers/OptionsContainer.jsx
@@ -147,7 +147,7 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    createAnswer: (buildingId, answer, headers) => createAnswer(buildingId, answer, headers, dispatch),
+    createAnswer: (buildingId, answer) => createAnswer(buildingId, answer, dispatch),
     uploadFile: (buildingId, questionId, file) => uploadFile(buildingId, questionId, file, dispatch),
     deleteFile: (buildingId, answer) => deleteFile(buildingId, answer, dispatch),
     downloadFile: (url, fileName) => downloadFile(url, fileName),

--- a/app/models/asset_manager.rb
+++ b/app/models/asset_manager.rb
@@ -55,6 +55,10 @@ class AssetManager < ApplicationRecord
     contains
   end
 
+  def create_answer(answer)
+    portfolio.buildings.include?(answer.building)
+  end
+
   def building_types
     portfolio.building_types
   end

--- a/app/models/manager_ability.rb
+++ b/app/models/manager_ability.rb
@@ -56,8 +56,12 @@ class ManagerAbility < ApplicationRecord
     # asset managers are granted full access to answers
     # only controller / frontend validation to handle
     # delegations
-    can [:create, :update, :read], Answer do |answer|
+    can [:update, :read], Answer do |answer|
       user.read_answer(answer)
+    end
+
+    can :create, Answer do |answer|
+      user.create_answer(answer)
     end
 
     can :read, Question do |question|


### PR DESCRIPTION
Fix cancancan so that asset managers can create answers without 403.

Also includes a bug fix discovered when testing.

Closes #201.