### PR TITLE
Answers reducer: keep fetch response

### DIFF
--- a/app/javascript/packs/reducers/answers.js
+++ b/app/javascript/packs/reducers/answers.js
@@ -56,6 +56,7 @@ function answerFetchSuccess(state, action) {
   return {
     ...state,
     [answer.question_id]: {
+      ...answer,
       ...localAnswer,
       updated_at: answer.updated_at || localAnswer.updated_at,
       fetchStatus: FETCH_SUCCESS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5687,6 +5687,14 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
+react-sane-contenteditable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-sane-contenteditable/-/react-sane-contenteditable-1.2.0.tgz#9c3f0a2c1caa90d7b8f54d3a1e20798752689a82"
+  dependencies:
+    lodash "^4.17.4"
+    prop-types "^15.6.0"
+    react "^16.0.0"
+
 react-transition-group@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
@@ -5694,6 +5702,15 @@ react-transition-group@^2.3.1:
     dom-helpers "^3.3.1"
     loose-envify "^1.3.1"
     prop-types "^15.6.1"
+
+react@^16.0.0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react@^16.3.1:
   version "16.3.1"
@@ -6658,7 +6675,13 @@ supports-color@^4.0.0, supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.1.0, supports-color@^5.3.0:
+supports-color@^5.1.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:


### PR DESCRIPTION
Resolves #220 

ONE-LINE PR!!!

Previously we were ignoring the fetch response answer object so that debounced inputs would work. However this caused issues with incomplete answer objects in delegations. The fix is to keep the fetch response by default, but spread over local answer afterwards, giving priority to local keys.
