### PR TITLE
Fix react-sane-contenteditable

### DIFF
--- a/app/javascript/packs/components/RangeOption.jsx
+++ b/app/javascript/packs/components/RangeOption.jsx
@@ -71,6 +71,7 @@ class RangeOption extends React.Component {
           innerRef={(ref) => this.ref = ref}
           tagName="span"
           content={currentValue}
+          doNotUpdate={true}
         />
         <label>{this.props.unit}</label>
       </div>

--- a/app/javascript/packs/components/RangeOption.jsx
+++ b/app/javascript/packs/components/RangeOption.jsx
@@ -58,7 +58,7 @@ class RangeOption extends React.Component {
       >
         <ContentEditable
           onChange={() => 0}
-          onKeyDown={(e) => this.onChange(e.target.innerText)}
+          onKeyDown={(e, val) => this.onChange(val)}
           onFocus={(e) => {
             this.setState({ focused: true });
             this.props.onEnter();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-moment": "^0.7.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
-    "react-sane-contenteditable": "^1.2.0",
+    "react-sane-contenteditable": "ethanlee16/react-sane-contenteditable",
     "react-transition-group": "^2.3.1",
     "redux": "^3.7.2",
     "redux-devtools": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-moment": "^0.7.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
-    "react-sane-contenteditable": "ethanlee16/react-sane-contenteditable",
+    "react-sane-contenteditable": "github:ethanlee16/react-sane-contenteditable#do-not-update",
     "react-transition-group": "^2.3.1",
     "redux": "^3.7.2",
     "redux-devtools": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5687,9 +5687,9 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-sane-contenteditable@^1.2.0:
+react-sane-contenteditable@ethanlee16/react-sane-contenteditable:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-sane-contenteditable/-/react-sane-contenteditable-1.2.0.tgz#9c3f0a2c1caa90d7b8f54d3a1e20798752689a82"
+  resolved "https://codeload.github.com/ethanlee16/react-sane-contenteditable/tar.gz/df5a3490b849eb1ab3f36f668337a30df27c5382"
   dependencies:
     lodash "^4.17.4"
     prop-types "^15.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5687,9 +5687,9 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-sane-contenteditable@ethanlee16/react-sane-contenteditable:
+"react-sane-contenteditable@github:ethanlee16/react-sane-contenteditable#do-not-update":
   version "1.2.0"
-  resolved "https://codeload.github.com/ethanlee16/react-sane-contenteditable/tar.gz/df5a3490b849eb1ab3f36f668337a30df27c5382"
+  resolved "https://codeload.github.com/ethanlee16/react-sane-contenteditable/tar.gz/82bf2fd6e4c41d4c0cfe3e35d4ba9a24b2a87423"
   dependencies:
     lodash "^4.17.4"
     prop-types "^15.6.0"


### PR DESCRIPTION
Patched `react-sane-contenteditable` to be up-to-date with the current value, through the second parameter of the `onKeyDown` callback.

This pull updates RangeOption to utilize this new value in the callback.