### PR TITLE
Answers reducer: start with default blank answer to avoid missing keys

### DIFF
--- a/app/javascript/packs/actions/answers.js
+++ b/app/javascript/packs/actions/answers.js
@@ -11,12 +11,29 @@ import {
 } from '../constants';
 import { post, postFile, patch, destroy } from '../fetch/requester';
 
+const EMPTY_ANSWER = {
+  text: '',
+  building_id: -1,
+  question_id: -1,
+  selected_option_id: null,
+  attachment_file_name: '',
+  attachment_content_type: '',
+  attachment_file_size: '',
+  attachment_updated_at: '',
+  delegation_email: '',
+  delegation_first_name: '',
+  delegation_last_name: '',
+};
+
 function answerFetchInProgress(buildingId, answer) {
   return {
     type: ANSWER_FETCH_IN_PROGRESS,
     fetchStatus: FETCH_IN_PROGRESS,
     buildingId,
-    answer
+    answer: {
+      ...EMPTY_ANSWER,
+      ...answer
+    }
   };
 }
 


### PR DESCRIPTION
Right now, for the `answerFetchInProgress` action, we are passing only the keys provided to be placed in store. For answers like file uploads which don't have some initial values (e.g. text), this is causing problems with undefined values. To solve this, spread over a default blank answer first so we have all the keys needed.