### PR TITLE
Remove get_scope arguments when loading user initial states

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
       user: current_asset_manager,
       buildings: ActiveModel::Serializer::CollectionSerializer.new(
           portfolio.buildings, each_serializer: BuildingSerializer,
-          scope: current_user.get_scope(current_user)
+          scope: current_user.get_scope
       ),
       building_types: ActiveModel::Serializer::CollectionSerializer.new(
         BuildingType.where(id: portfolio.buildings.map{ |b| b.building_type_id }.uniq),
@@ -65,7 +65,7 @@ module ApplicationHelper
       user: current_building_operator,
       buildings: ActiveModel::Serializer::CollectionSerializer.new(
        buildings, each_serializer: BuildingSerializer,
-       scope: current_user.get_building_scope(current_user)
+       scope: current_user.get_building_scope
       ),
       userType: 'BuildingOperator',
       contacts: contacts,
@@ -82,11 +82,11 @@ module ApplicationHelper
       portfolios: Portfolio.all,
       buildings: ActiveModel::Serializer::CollectionSerializer.new(
         Building.all, each_serializer: BuildingSerializer,
-        scope: current_user.get_scope(current_user)
+        scope: current_user.get_scope
       ),
       building_types: ActiveModel::Serializer::CollectionSerializer.new(
         BuildingType.all, each_serializer: BuildingTypeSerializer,
-        scope: current_user.get_scope(current_user)
+        scope: current_user.get_scope
       ),
       userType: 'RMIUser',
       categories: ActiveModel::Serializer::CollectionSerializer.new(

--- a/app/javascript/stylesheets/global.scss
+++ b/app/javascript/stylesheets/global.scss
@@ -25,12 +25,6 @@ body {
   margin: 0px;
 }
 
-h1 {
-  font-size: 38px;
-  text-align: center;
-  color: $titleGray;
-}
-
 .btn {
   border-radius: 3px;
   padding: 5px 20px 5px 20px;

--- a/app/models/building_operator.rb
+++ b/app/models/building_operator.rb
@@ -132,10 +132,10 @@ class BuildingOperator < ApplicationRecord
     BuildingOperatorMailer.existing_user_reminder_email(self).deliver_now
   end
 
-  def get_delegations(current_building_operator)
+  def get_delegations
     Delegation.includes(answer: [:question, :building]).where(
       answer: Answer.where(building: buildings),
-      building_operator: current_building_operator,
+      building_operator: self,
       status: "active"
     )
       .load.to_a
@@ -143,7 +143,7 @@ class BuildingOperator < ApplicationRecord
 
   # TODO 4/1: Do we want to use this scope instead when serializing buildings?
   # This limits the questions (supposedly) to only the ones that have been delegated to the current user
-  def get_building_scope(current_building_operator)
+  def get_building_scope
     building_questions = {}
     buildings.each do |b|
       building_questions[b.id] = questions_by_buildings([b.id])
@@ -152,7 +152,7 @@ class BuildingOperator < ApplicationRecord
     {
       user_id: id,
       user_type: 'BuildingOperator',
-      delegations: get_delegations(current_building_operator),
+      delegations: get_delegations,
       questions: building_questions
     }
   end
@@ -161,9 +161,9 @@ class BuildingOperator < ApplicationRecord
     {
       user_id: id,
       user_type: 'BuildingOperator',
-      delegations: get_delegations(current_building_operator),
+      delegations: get_delegations,
       questions: Question
-                   .where(id: current_building_operator.questions.map { |q| q.id }).load.to_a,
+                   .where(id: self.questions.map { |q| q.id }).load.to_a,
     }
   end
 end

--- a/app/models/rmi_user.rb
+++ b/app/models/rmi_user.rb
@@ -31,7 +31,7 @@ class RmiUser < ApplicationRecord
   validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, :on => :create
   validates :phone, :presence => true, :numericality => true, :length => { :minimum => 10, :maximum => 15}
 
-  def get_scope(_)
+  def get_scope
     {user_id: id, user_type: 'RmiUser'}
   end
 end


### PR DESCRIPTION
- Fixes the calls to `get_scope` in `application_helper.rb` when loading user states (we changed this method to have no arguments instead of 1)
- Also fixes a minor styling problem that affected the navbar